### PR TITLE
Present the journey step sheet outside the hosted pane

### DIFF
--- a/MimicUITests/JourneyUITests.swift
+++ b/MimicUITests/JourneyUITests.swift
@@ -313,11 +313,6 @@ final class JourneyUITests: XCTestCase {
 
     @MainActor
     func testCreateEmptyJourneyAndAddAStepByHand() throws {
-        // Skipped, not deleted: the step sheet does not open when the journey editor sits inside a
-        // hosted split pane, so this fails on a real defect rather than on the test.
-        // See https://github.com/srpadrono/mimic/issues/2 — remove this line when that is fixed.
-        throw XCTSkip("Journey step sheet does not present from a hosted pane — see issue #2")
-
         launchWithProject()
         showJourneysNavigator()
 
@@ -349,11 +344,6 @@ final class JourneyUITests: XCTestCase {
 
     @MainActor
     func testStepSheetRejectsAPathWithoutALeadingSlash() throws {
-        // Skipped, not deleted: the step sheet does not open when the journey editor sits inside a
-        // hosted split pane, so this fails on a real defect rather than on the test.
-        // See https://github.com/srpadrono/mimic/issues/2 — remove this line when that is fixed.
-        throw XCTSkip("Journey step sheet does not present from a hosted pane — see issue #2")
-
         launchWithProject()
         showJourneysNavigator()
 

--- a/Sources/AppFeatures/AppCore/AppState.swift
+++ b/Sources/AppFeatures/AppCore/AppState.swift
@@ -35,6 +35,16 @@ final class AppState {
     #endif
 
     var showNewEndpointSheet = false
+
+    /// The journey step waiting to be edited, or created when `step` is nil. Non-nil *is* "the step
+    /// sheet is up".
+    ///
+    /// It lives here rather than in `JourneyEditorView` because the editor is inside a hosted split
+    /// pane, and a SwiftUI modal cannot present from there — it begins a modal session the window
+    /// never shows, so "Add step" did nothing at all. `WorkspaceView` presents it instead, outside
+    /// that boundary, which is where every sheet that works already lives. `showNewEndpointSheet`
+    /// above is the same arrangement for the same reason.
+    var journeyStepEdit: JourneyStepEdit?
     /// The new-project sheet, presented by `ContentView` so one flag serves both the welcome window
     /// and an open workspace — File ▸ New Project has to work from either.
     var showNewProjectSheet = false

--- a/Sources/AppFeatures/AppCore/WorkspaceView.swift
+++ b/Sources/AppFeatures/AppCore/WorkspaceView.swift
@@ -297,6 +297,19 @@ struct WorkspaceView: View {
         } message: { alertData in
             Text("Another process is using port \(alertData.conflictingPort). Try port \(alertData.suggestedPort) instead?")
         }
+        // Presented here rather than in `JourneyEditorView`, because that view lives inside a hosted
+        // split pane and a SwiftUI modal cannot present from there — it starts a modal session the
+        // window never shows, so "Add step" silently did nothing. Every sheet in this file works for
+        // the same reason it is in this file.
+        .sheet(item: $appState.journeyStepEdit) { request in
+            JourneyStepSheet(step: request.step) { spec in
+                if let step = request.step {
+                    appState.updateJourneyStep(journeyID: request.journeyID, stepID: step.id, spec: spec)
+                } else {
+                    _ = appState.addJourneyStep(journeyID: request.journeyID, spec: spec)
+                }
+            }
+        }
         // New endpoint sheet
         .sheet(isPresented: $appState.showNewEndpointSheet) {
             NewEndpointSheet { name, method, path in

--- a/Sources/AppFeatures/JourneyFeature/JourneyEditorView.swift
+++ b/Sources/AppFeatures/JourneyFeature/JourneyEditorView.swift
@@ -19,8 +19,6 @@ struct JourneyEditorView: View {
     let isActive: Bool
     let status: JourneyStatus?
 
-    @State private var editingStepID: UUID?
-    @State private var showNewStepSheet = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,25 +38,8 @@ struct JourneyEditorView: View {
         // would take `journeyEditor.name`, `journeyEditor.addStepButton` and every `journeyStep-n`
         // out of the tree. Declaring the container here keeps them addressable whoever wraps it.
         .accessibilityElement(children: .contain)
-        .sheet(isPresented: $showNewStepSheet) {
-            JourneyStepSheet(step: nil) { spec in
-                appState.addJourneyStep(journeyID: journey.id, spec: spec)
-            }
-        }
-        .sheet(item: editingStep) { step in
-            JourneyStepSheet(step: step) { spec in
-                appState.updateJourneyStep(journeyID: journey.id, stepID: step.id, spec: spec)
-            }
-        }
     }
 
-    /// Binding shim so a step can be presented as a sheet item by id.
-    private var editingStep: Binding<JourneyStep?> {
-        Binding(
-            get: { journey.steps.first { $0.id == editingStepID } },
-            set: { editingStepID = $0?.id }
-        )
-    }
 
     // MARK: - Header
 
@@ -138,7 +119,7 @@ struct JourneyEditorView: View {
                 size: .small,
                 identifier: "journeyEditor.addStep"
             ) {
-                showNewStepSheet = true
+                appState.journeyStepEdit = JourneyStepEdit(journeyID: journey.id, step: nil)
             }
             .accessibilityIdentifier("journeyEditor.addStepButton")
             .accessibilityLabel("Add step")
@@ -284,7 +265,7 @@ struct JourneyEditorView: View {
                     + "than once — that is how a call fails and then succeeds.",
                 actionTitle: "Add step\u{2026}",
                 identifier: "journeyEditor.steps",
-                action: { showNewStepSheet = true }
+                action: { appState.journeyStepEdit = JourneyStepEdit(journeyID: journey.id, step: nil) }
             )
         } else {
             List {
@@ -295,10 +276,10 @@ struct JourneyEditorView: View {
                         progress: status?.steps.first { $0.id == step.id }
                     )
                     .contentShape(Rectangle())
-                    .onTapGesture { editingStepID = step.id }
+                    .onTapGesture { appState.journeyStepEdit = JourneyStepEdit(journeyID: journey.id, step: step) }
                     .contextMenu {
                         Button {
-                            editingStepID = step.id
+                            appState.journeyStepEdit = JourneyStepEdit(journeyID: journey.id, step: step)
                         } label: {
                             Label("Edit step\u{2026}", systemImage: "pencil")
                         }

--- a/Sources/AppFeatures/JourneyFeature/JourneyStepEdit.swift
+++ b/Sources/AppFeatures/JourneyFeature/JourneyStepEdit.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Domain
+
+/// A request to open the journey step sheet, raised by the editor and presented by the workspace.
+///
+/// The editor sits inside a hosted split pane and cannot present a sheet from there, so it records
+/// what it wants opened and `WorkspaceView` does the presenting. Carrying the journey's id as well as
+/// the step is what lets the presenter save to the right place without reaching back into the editor.
+struct JourneyStepEdit: Identifiable {
+    let journeyID: UUID
+    /// The step being edited, or `nil` to create one.
+    let step: JourneyStep?
+
+    var id: String {
+        "\(journeyID.uuidString)-\(step?.id.uuidString ?? "new")"
+    }
+}


### PR DESCRIPTION
Fixes #2.

## The bug

Clicking **Add step** in the journey editor did nothing. Same for editing an existing step. Shipped in
v0.9.3.

## Why

`JourneyEditorView` sits inside `DSSplitPane`, which hosts each pane in an `NSHostingController`
inside an `NSSplitViewController` inside an `NSViewControllerRepresentable`. A SwiftUI modal does not
survive that boundary: it starts a modal session — the window greys out — and then has nothing to
present on. The failure `.xcresult` showed exactly that: no `Sheet` element anywhere, main window
marked `Disabled`.

## The fix

The request moves to `AppState`, and `WorkspaceView` presents it — which is where the six sheets that
already work are presented, for precisely this reason. `showNewEndpointSheet` is the same arrangement
and predates this change.

`JourneyStepEdit` carries the journey's id alongside the step, so the presenter saves to the right
place without reaching back into the editor. A `nil` step means create.

## Verification

Both UI tests are un-skipped. They passed on the commit before the split pane and failed on the one
after, so they are the check on this — CI is the proof.

## Deliberately not in this PR

`EndpointEditorView` has an `.alert` inside the same boundary. No test covers it, so whether it is
affected is unverified. Worth a follow-up, but guessing at it is what made #2 take four attempts.