### PR TITLE
Let the journey editor's step area yield so the header stays reachable

### DIFF
--- a/MimicUITests/JourneyUITests.swift
+++ b/MimicUITests/JourneyUITests.swift
@@ -313,11 +313,6 @@ final class JourneyUITests: XCTestCase {
 
     @MainActor
     func testCreateEmptyJourneyAndAddAStepByHand() throws {
-        // Skipped, not deleted: the step sheet does not open when the journey editor sits inside a
-        // hosted split pane, so this fails on a real defect rather than on the test.
-        // See https://github.com/srpadrono/mimic/issues/2 — remove this line when that is fixed.
-        throw XCTSkip("Journey step sheet does not present from a hosted pane — see issue #2")
-
         launchWithProject()
         showJourneysNavigator()
 
@@ -349,11 +344,6 @@ final class JourneyUITests: XCTestCase {
 
     @MainActor
     func testStepSheetRejectsAPathWithoutALeadingSlash() throws {
-        // Skipped, not deleted: the step sheet does not open when the journey editor sits inside a
-        // hosted split pane, so this fails on a real defect rather than on the test.
-        // See https://github.com/srpadrono/mimic/issues/2 — remove this line when that is fixed.
-        throw XCTSkip("Journey step sheet does not present from a hosted pane — see issue #2")
-
         launchWithProject()
         showJourneysNavigator()
 

--- a/Sources/AppFeatures/JourneyFeature/JourneyEditorView.swift
+++ b/Sources/AppFeatures/JourneyFeature/JourneyEditorView.swift
@@ -32,7 +32,20 @@ struct JourneyEditorView: View {
             DSDivider(style: .standard, identifier: "journeyEditor.behavior")
             JourneyRunControls(journey: journey, isActive: isActive, status: status)
             DSDivider(identifier: "journeyEditor.run")
+            // Allowed to compress to nothing, and that is the whole point.
+            //
+            // Everything above this is a fixed height — the name row carrying "Add step", the
+            // behaviour controls, the run strip. The step area is not: with no steps it draws a
+            // `DSEmptyState`, which is tall and, without this, refuses to give any of it back. In a
+            // short window the stack then needed more room than the pane had and SwiftUI centred the
+            // overflow, which pushes the *top* row out of sight under the toolbar. "Add step" was
+            // drawn nowhere and could not be clicked, on CI and on any small window alike.
+            //
+            // Yielding here means the fixed rows keep their space and the step area takes what is
+            // left, which is the order that matters: you can always scroll a list, and you cannot
+            // reach a button that is not on screen.
             stepList
+                .frame(minHeight: 0, maxHeight: .infinity)
         }
         .background(DSColors.dominant)
         // The centre pane tags this view with an identifier of its own, and a bare


### PR DESCRIPTION
Fixes #2.

In a short window the journey editor's top row — carrying **Add step** — was drawn above its own
pane, under the toolbar, where it could not be clicked. The button stayed in the accessibility tree,
which is why the tests reported a successful click and then failed on a sheet that never opened.

## Cause

Everything above the step area is a fixed height: the name row, the behaviour controls, the run
strip. The step area is not — with no steps it draws a `DSEmptyState`, which is tall and would not
give any of it back. The stack then needed more room than the pane had, and SwiftUI centres an
overflow, which pushes the **top** out of sight.

Letting the step area compress to nothing keeps the fixed rows in place. You can scroll a list; you
cannot reach a button that is not drawn.

## Why it looked so confusing

It worked by hand and failed on CI because a hosted runner opens the window at macOS's default size
with no saved frame, and a normal window is tall enough that nothing overflows. It was never about
sheets, the hosting boundary, or any of the four other causes ruled out in #2.

## Verification

By hand, at the size that provoked it: window shrunk to ~530pt tall, a journey with no steps
selected, header row visible, **Add step** clicked, sheet opened.

Both UI tests are un-skipped and are the standing check.