### PR TITLE
Record the measured coverage in the README instead of discarding it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,23 @@ jobs:
       - name: Documented counts
         run: python3 Scripts/check_doc_counts.py
 
+      # `Scripts/update_readme_coverage.py` is what writes the README's coverage badges and table,
+      # and until this line it had no automated check of any kind. Half of it needs `xcrun xccov`
+      # and a real `.xcresult`, so only the macOS job can exercise that half — but the half that
+      # matters most to a reader, the one that rewrites README.md, is pure string work and runs
+      # anywhere. `--self-test` drives it against a fixture README: both badges, the generated
+      # block, the JSON round trip, prose outside the markers surviving, and the three refusals
+      # (a partial target list, a malformed payload, a README with no badges).
+      #
+      # It also pins the property the `record-coverage` job depends on — that rewriting with
+      # unchanged figures produces byte-identical output — because the day that stops being true is
+      # the day `main` starts collecting a commit per push.
+      #
+      # Here rather than on macOS for the same reason as the house rules above: it needs nothing a
+      # Mac has, and it is a tenth of a second.
+      - name: Coverage writer self-test
+        run: python3 Scripts/update_readme_coverage.py --self-test
+
       - name: Cache SwiftPM dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -198,6 +215,12 @@ jobs:
     # The Release build alone is several minutes on a 3-core runner, and the UI suite launches the
     # real app once per test.
     timeout-minutes: 120
+
+    # The measured coverage figures, handed to `record-coverage` below. Empty on every run that is
+    # not a push to `main`, and on any run that failed before the measurement — that job treats an
+    # empty value as "nothing to record" rather than as an error.
+    outputs:
+      coverage: ${{ steps.figures.outputs.json }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -345,6 +368,48 @@ jobs:
             --result-bundle .artifacts/coverage/UnitTests.xcresult \
             --title 'Code coverage (unit suites, XCUITest excluded)' \
             | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # (c): the same figures again, as a few hundred bytes of JSON handed to the `record-coverage`
+      # job at the bottom of this file, which writes them into README.md.
+      #
+      # A **job output**, not an artifact, and not three more lines on this job. Two constraints
+      # meet here. `contents: write` must not live on this job — it is the one that compiles and
+      # runs code out of a pull request, and a write token here would widen the blast radius of
+      # anything going wrong in that to "can push to `main`". And the `.xcresult` this reads is
+      # several hundred megabytes, so handing the *bundle* to a second job would move all of it
+      # between runners so the other end could re-read nine numbers out of it. An output carries
+      # exactly the nine numbers, costs nothing, and needs no `download-artifact` — which this
+      # workflow has never pinned, and a SHA is not a thing to guess at.
+      #
+      # `continue-on-error`, for the same reason the summary step above carries it and no weaker: a
+      # coverage measurement is not a verdict on a commit, and a step that reddens a run whose tests
+      # all passed teaches people to ignore red. It matters more here than there, because the exact
+      # names `xccov` reports targets under in a *workspace-wide* bundle could not be checked from
+      # where this was written — no Mac, no Xcode — and `--emit-json` deliberately refuses to write
+      # a partial table, all nine targets or none, rather than shrinking the badge's denominator
+      # into a pass.
+      #
+      # That refusal is safe to leave loud-but-not-fatal because its failure announces itself: no
+      # figures means no recording, and the badges in the README go on reading `not measured` until
+      # somebody looks. A silent wrong number is the outcome worth engineering against; a visibly
+      # absent one is not.
+      #
+      # Only on a push to `main`: on a pull request there is nowhere to record the result, and the
+      # numbers describe the merged commit anyway.
+      - name: Emit coverage figures
+        id: figures
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        run: |
+          python3 Scripts/update_readme_coverage.py \
+            --result-bundle .artifacts/coverage/UnitTests.xcresult \
+            --emit-json .artifacts/coverage/coverage.json
+          cat .artifacts/coverage/coverage.json
+          {
+            echo 'json<<COVERAGE_JSON_EOF'
+            cat .artifacts/coverage/coverage.json
+            echo 'COVERAGE_JSON_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       # The reason this job exists. XCUITest is the only thing that exercises the real window — the
       # accessibility tree, the panel layout, and every flow a user actually takes.
@@ -506,3 +571,111 @@ jobs:
             .artifacts/coverage/UnitTests.xcresult
           retention-days: 7
           if-no-files-found: ignore
+
+  # The one job in this workflow that writes to the repository. It records the coverage the macOS
+  # job measured into README.md's two badges and the block between its `coverage:generated`
+  # markers — the thing both badges spent this repository's whole history saying `not measured` for
+  # while the number was being computed on every run and thrown away with the runner.
+  #
+  # Why this is a separate job on Linux rather than three more lines on the macOS one is argued at
+  # `Emit coverage figures` above: `contents: write` must not sit on the job that compiles and runs
+  # code out of a pull request. What runs here is one stdlib Python script over one Markdown file.
+  # No build, no test, no repository code executes.
+  #
+  # `always()`, guarded to pushes on `main`. Coverage is measured two steps before XCUITest starts,
+  # and this repository's UI suite is documented as ending red on a test that passed on its retry —
+  # letting that decide whether the number is recorded would mean the README updates only on runs
+  # where a flake happened not to fire. A macOS job that died *before* the measurement leaves the
+  # output empty, which the first step below reports and stops on.
+  record-coverage:
+    name: Record coverage in README
+    needs: macos
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # `main` rather than the pushed SHA, because the number goes where a reader will look for
+          # it. `fetch-depth: 0` because the push at the end may have to rebase onto a tip that
+          # moved while the macOS job was still running, and a depth-1 clone has nothing to rebase
+          # onto.
+          ref: main
+          fetch-depth: 0
+
+      # The job output goes through `env:` rather than straight into `run:`. A `${{ }}` interpolated
+      # into a shell line is substituted before the shell ever sees it, so its content is parsed as
+      # script; through the environment it can only ever be data. This particular value is a number
+      # this workflow computed rather than anything a stranger wrote — the habit is the point.
+      - name: Write the figures out
+        id: figures
+        env:
+          COVERAGE_JSON: ${{ needs.macos.outputs.coverage }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COVERAGE_JSON:-}" ]; then
+            echo "No coverage figures in this run: the macOS job did not reach the measurement."
+            echo "state=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p .artifacts/coverage
+          printf '%s\n' "$COVERAGE_JSON" > .artifacts/coverage/coverage.json
+          echo "state=ready" >> "$GITHUB_OUTPUT"
+
+      # `main` is a protected branch. Whether these rules let this token push is a repository
+      # setting rather than anything a commit can fix, so a rejection must not redden a commit whose
+      # tests all passed: the step warns, and puts the diff it wanted to make into the job summary
+      # where somebody can apply it by hand. The number is never lost, at worst it is not committed.
+      - name: Record it in README.md
+        if: steps.figures.outputs.state == 'ready'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          python3 Scripts/update_readme_coverage.py \
+            --from-json .artifacts/coverage/coverage.json \
+            --readme README.md
+
+          # The generated block is a pure function of the figures — no timestamp, no run URL — so an
+          # unchanged measurement leaves the file byte-identical and there is nothing to commit.
+          # Without that property `main` would grow one commit per push forever.
+          if git diff --quiet -- README.md; then
+            echo "README.md already records these figures — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          # `[skip ci]` is load-bearing: without it this commit triggers the workflow that wrote it.
+          git commit -m 'docs: record measured coverage in the README [skip ci]'
+
+          if git push origin HEAD:main; then
+            echo "Recorded."
+            exit 0
+          fi
+
+          # A push can also simply lose a race — `main` moved while the macOS job was running. That
+          # is worth exactly one rebase before concluding the branch rules are what rejected it.
+          echo "Push rejected; rebasing onto main and trying once more."
+          if git pull --rebase origin main && git push origin HEAD:main; then
+            echo "Recorded after a rebase."
+            exit 0
+          fi
+
+          echo "::warning::Could not push the coverage update to main — the diff is in the job summary."
+          patch="$(git diff 'HEAD^' HEAD -- README.md || true)"
+          {
+            echo '### Coverage measured, but not recorded'
+            echo
+            echo 'The push to `main` was rejected. If branch protection is what refused it, either'
+            echo 'allow the Actions bot to bypass the rule for this path, or apply the diff below by'
+            echo 'hand. The figures themselves are in the macOS job'"'"'s summary and its job output.'
+            echo
+            echo '```diff'
+            printf '%s\n' "$patch"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,9 @@ at generation time, not written by anyone here.
 
 This section used to say the per-module schemes "build the frameworks but do not bundle their test
 targets", and that is why `Mimic-Workspace` was presented as the only way to run a unit suite. It
-cannot be right: [`Scripts/run_full_test_suite.sh`](Scripts/run_full_test_suite.sh) — the sole
-producer of the README's coverage numbers — runs `xcodebuild -scheme Domain test` and six more against exactly
+cannot be right: [`Scripts/run_full_test_suite.sh`](Scripts/run_full_test_suite.sh) — one of the two
+producers of the README's coverage numbers, the other being CI's `record-coverage` job — runs
+`xcodebuild -scheme Domain test` and six more against exactly
 those schemes, and `Scripts/update_readme_coverage.py` then reads the `Domain.xcresult`,
 `ControlPlane.xcresult` … bundles they leave behind. A scheme with nothing testable in it fails
 immediately with *"Scheme X is not currently configured for the test action"* and produces no bundle,
@@ -94,9 +95,13 @@ xcodebuild -workspace Mimic.xcworkspace -list      # every scheme Tuist actually
 
 ### What CI actually covers
 
-CI runs on every pull request and on every push to `main`, in two jobs split by what actually needs a
-Mac. Both are free: GitHub does not meter standard hosted runners on public repositories, macOS
-included.
+CI runs on every pull request and on every push to `main`, in three jobs. Two are split by what
+actually needs a Mac; the third, `record-coverage`, is a short Linux job that runs only on pushes to
+`main` and writes the coverage the macOS job measured into the README's two badges and its
+`coverage:generated` block. It is the only job in the workflow holding `contents: write`, and it
+holds it precisely so that the job compiling code out of a pull request does not — see the comments
+above it and above `Emit coverage figures`. Both runners are free: GitHub does not meter standard
+hosted runners on public repositories, macOS included.
 
 **Linux** builds through [`Package.swift`](Package.swift) rather than Tuist — the domain rules, mock
 engine, persistence, control plane, spec import and CLI are plain Swift, so most of the suite reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,10 @@ xcodebuild -workspace Mimic.xcworkspace -scheme Mimic -configuration Release \
 `Project.swift` declares exactly one scheme, `Mimic`. Everything else you can pass to `-scheme` —
 `Mimic-Workspace` and one per module — is inferred by Tuist, and the inferred per-module schemes do
 carry their `<Module>Tests` target: `Scripts/run_full_test_suite.sh` runs `xcodebuild -scheme Domain
-test` and six more, and README's coverage section is generated from the `.xcresult` bundles they
-produce. (This file used to claim the opposite, which is why `Mimic-Workspace` was presented as the
+test` and six more, and README's coverage section can be generated from the `.xcresult` bundles they
+produce. (CI writes that same section on every push to `main`, from the one workspace-wide bundle
+its macOS job measures — so running the full suite locally is no longer the only way the badges
+ever move.) (This file used to claim the opposite, which is why `Mimic-Workspace` was presented as the
 only way to run a unit suite. Prefer it because it covers everything in one pass, not because the
 others cannot test.) `xcodebuild -workspace Mimic.xcworkspace -list` prints what was actually
 generated.

--- a/README.md
+++ b/README.md
@@ -326,16 +326,41 @@ structurally: XCUITest, because the step doing the measuring is the one that ski
 the Linux job runs, because gathering coverage needs the Xcode toolchain. On a red run the bundle is
 uploaded as the `xcresult` artifact, which is where per-file detail lives.
 
-**The two badges above still read `not measured`, and that is now a different fact from the one this
-section used to record.** The number exists; nothing publishes it here. This workflow holds
-`contents: read` and writes nothing back to the repository, so both badges are still rewritten only
-by [`Scripts/update_readme_coverage.py`](Scripts/update_readme_coverage.py) — from a Mac, out of the
-per-scheme bundles the full suite produces, and committed by whoever ran it:
+**The numbers are also recorded here, on every push to `main`.** They used to exist only in that job
+summary — computed on every run and thrown away with the runner — which is why both badges above
+spent this repository's entire history reading `not measured` while the measurement was already
+happening. The `record-coverage` job closes that: the macOS job hands its figures on as a job
+output, and that job rewrites the two badges and the block below with
+[`Scripts/update_readme_coverage.py`](Scripts/update_readme_coverage.py).
+
+Four things about it are deliberate, and each is the answer to a way this normally goes wrong:
+
+- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS job
+  compiles and runs code out of a pull request; a write token there would widen the blast radius of
+  anything going wrong in it to "can push to `main`". The recording job runs one Python script over
+  one Markdown file.
+- **A few hundred bytes cross between them, not the bundle.** The `.xcresult` is hundreds of
+  megabytes and stays on the runner that made it.
+- **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
+  coverage figures, so an unchanged measurement leaves the file byte-identical and there is nothing
+  to commit — otherwise `main` would collect one commit per push forever. The commit that is made
+  carries `[skip ci]`, or it would trigger the workflow that wrote it.
+- **It records; it never gates.** `main` is a protected branch, and whether its rules let the Actions
+  bot push is a repository setting rather than something a commit can fix. A rejected push warns and
+  prints the diff it wanted to make into the job summary — it never reddens a commit whose tests
+  passed.
+
+A Mac still writes the same section from a full local suite, out of the per-scheme bundles rather
+than the workspace-wide one, and the generated block says which of the two produced it:
 
 ```bash
 ./Scripts/ci.sh                     # the CI gate locally, and prints the same per-target table
 ./Scripts/run_full_test_suite.sh    # macOS + Xcode; rewrites this section and the two badges
 ```
+
+The half of that script needing no Mac — the rewriting, the JSON hand-off and the refusals — is
+covered by `python3 Scripts/update_readme_coverage.py --self-test`, which the Linux job runs beside
+the other checkers. It had no automated test of any kind before it started writing to `main`.
 
 **No coverage floor is enforced, deliberately.** A threshold picked before anybody has seen the
 number is either so low it never fires or red on the run that introduces it. Measuring first, then
@@ -345,9 +370,10 @@ setting the floor against a baseline, is the order.
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
-`main`, in two jobs: Linux builds `Package.swift` and runs the portable suites in a couple of
+`main`, in three jobs: Linux builds `Package.swift` and runs the portable suites in a couple of
 minutes, macOS runs `tuist generate`, the Debug build, the app-level suites — measured, with the
-per-target coverage table printed into the job summary — XCUITest and the Release gate. Both runners
+per-target coverage table printed into the job summary — XCUITest and the Release gate, and a short
+`record-coverage` job writes those figures into this file on pushes to `main`. Both runners
 are free on a public repository. (This section used to say Actions could not start
 a job here at all — true while the repository was private and a billing block killed every run in
 about two seconds; making it public resolved it.)

--- a/Scripts/update_readme_coverage.py
+++ b/Scripts/update_readme_coverage.py
@@ -1,19 +1,36 @@
 #!/usr/bin/env python3
 
-"""Reads line coverage out of `.xcresult` bundles. Two modes, one reader.
+"""Reads line coverage out of `.xcresult` bundles. One reader, four callers.
 
 **`--results-dir`** is the mode `Scripts/run_full_test_suite.sh` uses: one bundle per scheme, on a
 Mac, after a full suite run. It rewrites README.md's two coverage badges and the block between the
 `coverage:generated` markers, in place.
 
-**`--result-bundle`** is the mode `.github/workflows/ci.yml` uses: one bundle — the workspace-wide
-unit run — printed as Markdown on stdout and appended to the job summary. It reads the bundle and
-changes nothing, so it is safe on a pull request from a fork, where the token is read-only and a
-README rewrite could not be committed anyway.
+**`--result-bundle`** is the mode `.github/workflows/ci.yml` uses for the job summary: one bundle —
+the workspace-wide unit run — printed as Markdown on stdout. It reads the bundle and changes
+nothing, so it is safe on a pull request from a fork, where the token is read-only and a README
+rewrite could not be committed anyway.
 
-Both modes go through `target_metrics`, so the numbers a reviewer reads in a job summary and the
-numbers a Mac writes into the README come out of one piece of code rather than two that agree by
-hand.
+**`--result-bundle --emit-json`** writes those same numbers to a small JSON file instead of printing
+them. It is what the macOS job hands to the job that records them, so a several-hundred-megabyte
+`.xcresult` never has to leave the runner that produced it.
+
+**`--from-json --readme`** rewrites the README from that file. It needs neither Xcode nor a bundle,
+which is what lets the recording job run on Linux holding `contents: write` while the job that
+compiles code out of a pull request keeps a read-only token. It rewrites *only* the two badges and
+the generated block, so a README edited between the measurement and the recording keeps the rest of
+its changes.
+
+Every mode goes through `target_metrics`, so the numbers a reviewer reads in a job summary and the
+numbers written into the README come out of one piece of code rather than two that agree by hand.
+
+**Nothing generated here carries a timestamp, a run number or a run URL, deliberately.** The block
+is a pure function of the coverage figures, so an unchanged measurement produces a byte-identical
+README and the recording job's `git diff --quiet` finds nothing to commit. Put a run URL in it and
+`main` grows a commit per push forever.
+
+`--self-test` exercises the JSON round trip and both rewriters against a fixture README, so the half
+of this file that needs no Mac is checked on every Linux CI run.
 
 Stdlib only, so the Linux CI container's `python3-minimal` and a Mac's system Python both run it.
 """
@@ -24,7 +41,7 @@ import argparse
 import json
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
@@ -157,12 +174,18 @@ def format_lines(metrics: CoverageMetrics) -> str:
     return f"{metrics.covered_lines:,}/{metrics.executable_lines:,}"
 
 
-def build_coverage_block(app_metrics: CoverageMetrics, module_metrics: list[tuple[str, CoverageMetrics]]) -> str:
+def build_coverage_block(
+    app_metrics: CoverageMetrics,
+    module_metrics: list[tuple[str, CoverageMetrics]],
+    *,
+    generated_from: str,
+    provenance: str,
+) -> str:
     lines = [
         "<!-- coverage:generated:start -->",
-        "This section is auto-generated from the latest coverage-enabled `.xcresult` bundles produced by `./Scripts/run_full_test_suite.sh`.",
+        f"This section is auto-generated — do not edit it by hand. {generated_from}",
         "",
-        "Latest measured coverage from the most recent successful full-suite run:",
+        "Latest measured line coverage:",
         "",
         "| Target | Coverage | Lines |",
         "| --- | ---: | ---: |",
@@ -184,7 +207,7 @@ def build_coverage_block(app_metrics: CoverageMetrics, module_metrics: list[tupl
             f"- Total executable lines tracked in this table: `{total_executable_lines:,}`.",
             "- `Lines` shows covered/executable lines reported by `xcrun xccov`.",
             "- Coverage is gathered with `xcodebuild` and `xcrun xccov` from fresh `.xcresult` bundles.",
-            "- The macOS CI job measures the same thing per run and prints it in its job summary; these numbers are from whoever last ran the full suite on a Mac.",
+            f"- {provenance}",
             "<!-- coverage:generated:end -->",
         ]
     )
@@ -293,6 +316,71 @@ def report_one_bundle(result_bundle: Path, title: str) -> int:
     return 0
 
 
+# The two provenance wordings. They differ because the two writers are answering different
+# questions for a reader who finds a number in the README and wants to know how stale it is: one is
+# "a human ran this on their Mac at some point", the other is "CI measured this on the commit that
+# is `main` right now".
+FULL_SUITE_GENERATED_FROM = (
+    "It is written from the coverage-enabled `.xcresult` bundles `./Scripts/run_full_test_suite.sh` "
+    "produces on a Mac, one per scheme."
+)
+FULL_SUITE_PROVENANCE = (
+    "These numbers are from whoever last ran the full suite on a Mac. CI measures the same thing on "
+    "every run and records it here on every push to `main`, so this wording means a local run "
+    "overtook the last recorded one."
+)
+CI_GENERATED_FROM = (
+    "It is written by CI on every push to `main`, from the workspace-wide unit run the macOS job "
+    "measures with `-enableCodeCoverage YES`."
+)
+CI_PROVENANCE = (
+    "XCUITest is not in these figures: the step that measures coverage is the one passing "
+    "`-skip-testing:MimicUITests`, and the Linux job gathers no coverage at all. No floor is "
+    "enforced against them — this records, it does not gate."
+)
+
+
+def render_readme(
+    readme: str,
+    app_metrics: CoverageMetrics,
+    module_metrics: list[tuple[str, CoverageMetrics]],
+    *,
+    generated_from: str,
+    provenance: str,
+) -> str:
+    """The whole rewrite as a string function, so `--self-test` can check it without touching disk."""
+    modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
+    readme = replace_badges(readme, app_metrics.percent, modules_at_or_above_95, len(module_metrics))
+    return replace_coverage_block(
+        readme,
+        build_coverage_block(
+            app_metrics,
+            module_metrics,
+            generated_from=generated_from,
+            provenance=provenance,
+        ),
+    )
+
+
+def write_readme(
+    readme_path: Path,
+    app_metrics: CoverageMetrics,
+    module_metrics: list[tuple[str, CoverageMetrics]],
+    *,
+    generated_from: str,
+    provenance: str,
+) -> None:
+    readme_path.write_text(
+        render_readme(
+            readme_path.read_text(),
+            app_metrics,
+            module_metrics,
+            generated_from=generated_from,
+            provenance=provenance,
+        )
+    )
+
+
 def update_readme(readme_path: Path, results_dir: Path) -> None:
     app_metrics = metrics_for_target(results_dir / APP_TARGET[2], APP_TARGET[1])
 
@@ -300,18 +388,188 @@ def update_readme(readme_path: Path, results_dir: Path) -> None:
     for display_name, xccov_name, filename in MODULE_TARGETS:
         module_metrics.append((display_name, metrics_for_target(results_dir / filename, xccov_name)))
 
-    readme = readme_path.read_text()
-    modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
-    readme = replace_badges(readme, app_metrics.percent, modules_at_or_above_95, len(module_metrics))
-    readme = replace_coverage_block(readme, build_coverage_block(app_metrics, module_metrics))
-    readme_path.write_text(readme)
+    write_readme(
+        readme_path,
+        app_metrics,
+        module_metrics,
+        generated_from=FULL_SUITE_GENERATED_FROM,
+        provenance=FULL_SUITE_PROVENANCE,
+    )
+
+
+def split_workspace_metrics(
+    metrics: dict[str, CoverageMetrics],
+) -> tuple[CoverageMetrics, list[tuple[str, CoverageMetrics]]]:
+    """Pick the README's nine targets out of one workspace-wide report.
+
+    Every one of them has to be there. A partial table is worse than none: the badge's denominator
+    is `len(module_metrics)`, so a module that silently dropped out of the bundle would shrink
+    "modules at or above 95%: n/8" to `n/7` and read as a pass. That exact failure is why
+    `ControlPlane` and `MimicCLICore` were once measured and invisible — see `MODULE_TARGETS`.
+    """
+    wanted = [APP_TARGET[1]] + [xccov_name for _, xccov_name, _ in MODULE_TARGETS]
+    missing = [name for name in wanted if name not in metrics]
+    if missing:
+        found = ", ".join(sorted(metrics)) or "no targets at all"
+        raise RuntimeError(
+            f"the report is missing {', '.join(missing)} — it has {found}. Refusing to write a "
+            "partial coverage table."
+        )
+    return metrics[APP_TARGET[1]], [
+        (display_name, metrics[xccov_name]) for display_name, xccov_name, _ in MODULE_TARGETS
+    ]
+
+
+def emit_json(result_bundle: Path, destination: Path) -> None:
+    app_metrics, module_metrics = split_workspace_metrics(target_metrics(result_bundle))
+    payload = {
+        "app": {"name": APP_TARGET[0], **asdict(app_metrics)},
+        "modules": [{"name": name, **asdict(metrics)} for name, metrics in module_metrics],
+    }
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def update_readme_from_json(readme_path: Path, json_path: Path) -> None:
+    try:
+        payload = json.loads(json_path.read_text())
+        app_metrics = CoverageMetrics(
+            percent=float(payload["app"]["percent"]),
+            covered_lines=int(payload["app"]["covered_lines"]),
+            executable_lines=int(payload["app"]["executable_lines"]),
+        )
+        module_metrics = [
+            (
+                str(entry["name"]),
+                CoverageMetrics(
+                    percent=float(entry["percent"]),
+                    covered_lines=int(entry["covered_lines"]),
+                    executable_lines=int(entry["executable_lines"]),
+                ),
+            )
+            for entry in payload["modules"]
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        raise RuntimeError(f"{json_path} is not a coverage payload this script wrote: {error}") from error
+
+    if not module_metrics:
+        raise RuntimeError(f"{json_path} carries no modules; refusing to write a table with none.")
+
+    write_readme(
+        readme_path,
+        app_metrics,
+        module_metrics,
+        generated_from=CI_GENERATED_FROM,
+        provenance=CI_PROVENANCE,
+    )
+
+
+FIXTURE_README = """# Fixture
+
+[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
+[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
+
+Prose that must survive untouched.
+
+<!-- coverage:generated:start -->
+<!-- coverage:generated:end -->
+
+Trailing prose.
+"""
+
+
+def self_test() -> int:
+    """Check the Mac-free half: the JSON round trip, both rewriters, and the refusals.
+
+    This is the only automated coverage the file has. The bundle-reading half needs `xcrun xccov`
+    and a real `.xcresult`, so it is exercised only by the macOS job; everything below runs in a
+    tenth of a second on the Linux gate alongside the other checkers.
+    """
+    import tempfile
+
+    failures: list[str] = []
+
+    def check(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    app = CoverageMetrics(percent=41.5, covered_lines=1_000, executable_lines=2_409)
+    modules = [
+        ("Domain.framework", CoverageMetrics(percent=96.0, covered_lines=960, executable_lines=1_000)),
+        ("ControlPlane.framework", CoverageMetrics(percent=80.25, covered_lines=321, executable_lines=400)),
+    ]
+
+    rendered = render_readme(
+        FIXTURE_README, app, modules, generated_from="From a fixture.", provenance="Fixture note."
+    )
+    check("not%20measured" not in rendered, "a badge still reads 'not measured' after a rewrite")
+    check("41.50%25" in rendered, "the app badge does not carry the measured percentage")
+    check("1%2F2" in rendered, "the module badge does not carry the at-or-above-95 count")
+    check("`Domain.framework` | `96.00%` | `960/1,000`" in rendered, "a module row is missing or misformatted")
+    check("Prose that must survive untouched." in rendered, "prose outside the markers was lost")
+    check("Trailing prose." in rendered, "prose after the block was lost")
+    check(rendered.count("coverage:generated:start") == 1, "the start marker was duplicated or dropped")
+    check(rendered.count("coverage:generated:end") == 1, "the end marker was duplicated or dropped")
+
+    # Idempotence is what makes "commit only when the numbers moved" true: rewriting the *rendered*
+    # README with the same figures has to produce the same bytes, markers and badges included.
+    again = render_readme(
+        rendered, app, modules, generated_from="From a fixture.", provenance="Fixture note."
+    )
+    check(again == rendered, "rewriting with unchanged figures produced a different README")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        readme_path = Path(tmp) / "README.md"
+        readme_path.write_text(FIXTURE_README)
+        json_path = Path(tmp) / "coverage.json"
+        json_path.write_text(
+            json.dumps(
+                {
+                    "app": {"name": "Mimic.app", **asdict(app)},
+                    "modules": [{"name": name, **asdict(metrics)} for name, metrics in modules],
+                }
+            )
+        )
+        update_readme_from_json(readme_path, json_path)
+        from_json = readme_path.read_text()
+        check("41.50%25" in from_json, "--from-json did not rewrite the app badge")
+        check(CI_PROVENANCE in from_json, "--from-json did not use the CI provenance wording")
+
+        json_path.write_text("{\"app\": {}}")
+        try:
+            update_readme_from_json(readme_path, json_path)
+            failures.append("a malformed payload was accepted")
+        except RuntimeError:
+            pass
+
+    try:
+        split_workspace_metrics({"Domain.framework": app})
+        failures.append("a report missing eight of nine targets was accepted")
+    except RuntimeError as error:
+        check("Mimic.app" in str(error), "the refusal does not name what was missing")
+
+    try:
+        render_readme("# No badges here", app, modules, generated_from="x", provenance="y")
+        failures.append("a README with no badges was accepted")
+    except RuntimeError:
+        pass
+
+    for failure in failures:
+        print(f"  FAIL {failure}")
+    print(
+        "update_readme_coverage self-test: "
+        + ("all checks passed." if not failures else f"{len(failures)} failure(s).")
+    )
+    return 1 if failures else 0
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Read coverage from .xcresult bundles: rewrite README, or print a Markdown report."
     )
-    parser.add_argument("--readme", default="README.md", help="Path to README.md (--results-dir mode only)")
+    parser.add_argument(
+        "--readme", default="README.md", help="Path to README.md (--results-dir and --from-json modes)"
+    )
     parser.add_argument(
         "--results-dir",
         help="Directory of per-scheme bundles, as Scripts/run_full_test_suite.sh produces. Rewrites the README.",
@@ -320,14 +578,46 @@ def main() -> None:
         "--result-bundle",
         help="A single .xcresult. Prints a Markdown report on stdout and edits nothing.",
     )
+    parser.add_argument(
+        "--emit-json",
+        help="With --result-bundle: write the figures to this path instead of printing them.",
+    )
+    parser.add_argument(
+        "--from-json",
+        help="A file written by --emit-json. Rewrites the README from it. Needs no Xcode.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Check the rewriters and the JSON round trip against a fixture. Needs no Xcode.",
+    )
     parser.add_argument("--title", default="Code coverage", help="Heading for --result-bundle output.")
     args = parser.parse_args()
 
-    if bool(args.results_dir) == bool(args.result_bundle):
-        parser.error("pass exactly one of --results-dir or --result-bundle")
+    modes = [bool(args.results_dir), bool(args.result_bundle), bool(args.from_json), args.self_test]
+    if sum(modes) != 1:
+        parser.error("pass exactly one of --results-dir, --result-bundle, --from-json or --self-test")
+    if args.emit_json and not args.result_bundle:
+        parser.error("--emit-json only means something with --result-bundle")
+
+    if args.self_test:
+        raise SystemExit(self_test())
+
+    if args.from_json:
+        update_readme_from_json(Path(args.readme).resolve(), Path(args.from_json).resolve())
+        return
 
     if args.result_bundle:
-        raise SystemExit(report_one_bundle(Path(args.result_bundle).resolve(), args.title))
+        bundle = Path(args.result_bundle).resolve()
+        if args.emit_json:
+            # Raises rather than printing a reason and exiting 1, unlike `report_one_bundle` above:
+            # nobody is reading this step's stdout as a report, and the caller wants a file or a
+            # failure. The workflow marks the step `continue-on-error`, so the failure surfaces as a
+            # warning and the README simply goes on saying whatever it last said — which, until the
+            # first successful recording, is `not measured`.
+            emit_json(bundle, Path(args.emit_json).resolve())
+            return
+        raise SystemExit(report_one_bundle(bundle, args.title))
 
     update_readme(Path(args.readme).resolve(), Path(args.results_dir).resolve())
 


### PR DESCRIPTION
Coverage has been measured on every macOS run since the workspace scheme started carrying `-enableCodeCoverage YES`, and then thrown away with the runner — the per-target table goes to `$GITHUB_STEP_SUMMARY` and nowhere else. That is why both README badges have read `not measured` since the initial commit (`cac602a` is the only commit that has ever touched those two lines) while the number was already being computed on every run.

It is also effectively unreadable after the fact: a job summary is not exposed by the REST API, the check run's `output.text` is empty, and the job-log endpoint returns only a ~5,000-line tail — the `Coverage report` step sits roughly 45,000 lines before the end of a green run, behind `Test (UI)` and `Build (Release)`. Across all 60 runs of this workflow, exactly one ended early enough to bring that step near the tail, and it still missed by 75 seconds. This PR's own writeup of the tail cap is the same one [#52](https://github.com/srpadrono/mimic/pull/52) hit diagnosing the context-menu bug.

A new `record-coverage` job writes the figures into README.md on pushes to `main`.

## How it fits together

`Emit coverage figures` (macOS) reads the workspace-wide bundle it already produced and hands nine numbers on as a **job output**. `record-coverage` (Linux, ~20 s) rewrites the two badges and the `coverage:generated` block with `Scripts/update_readme_coverage.py --from-json`, commits, and pushes.

Four decisions, each answering a way this normally goes wrong:

- **Separate job, and the only one in the workflow holding `contents: write`.** The macOS job compiles and runs code out of a pull request; a write token there would widen the blast radius of anything going wrong in it to "can push to `main`". The recording job runs one stdlib Python script over one Markdown file — no build, no test, no repository code.
- **A job output, not an artifact.** The `.xcresult` is hundreds of megabytes and stays on the runner that made it. It also means no `download-artifact` pin was needed — this workflow has never carried one, and an action SHA is not a thing to guess at.
- **The generated block carries no timestamp, run number or run URL.** It is a pure function of the coverage figures, so an unchanged measurement leaves the file byte-identical and `git diff --quiet` finds nothing to commit. Without that property `main` would collect one commit per push forever. The commit that is made carries `[skip ci]`, or it would trigger the workflow that wrote it.
- **It records; it never gates.** A rejected push warns and prints the diff it wanted to make into the job summary. `Emit coverage figures` is `continue-on-error` for the same reason the summary step above it is: a coverage measurement is not a verdict on a commit, and a step that reddens a run whose tests all passed teaches people to ignore red. No floor is introduced — that argument is unchanged.

## Script changes

`--emit-json` and `--from-json` sit either side of the hand-off, both going through the existing `target_metrics` so the summary table and the README table stay one piece of code. `--from-json` rewrites **only** the badges and the generated block, so a README edited between the measurement and the recording keeps its other changes.

`split_workspace_metrics` refuses to write a partial table — all nine targets or none — rather than shrinking the badge's denominator into a pass. That is the failure that once left `ControlPlane` and `MimicCLICore` measured but invisible, and `MODULE_TARGETS` still carries the comment about it.

The script had **no automated test of any kind** before it started writing to `main`. `--self-test` covers the half that needs no Mac — both rewriters, the JSON round trip, prose outside the markers surviving, idempotence, and three refusals (partial target list, malformed payload, a README with no badges) — and the Linux job runs it beside the other checkers.

## Verification

Everything the Linux job runs passes locally: house rules (7 rules, self-test included), lockfiles, compiler settings, module edges, documented counts, and the new self-test.

The emit → record chain was simulated end to end against the real README with a faked `xccov` report: badges rewritten, eight framework rows, `.xctest` bundles correctly excluded, the second rewrite byte-identical, and a report missing one framework refused by name.

**What is not verified, and cannot be from here:** anything needing Xcode. This environment has no Swift toolchain, no Docker daemon and no Mac, so `--emit-json` has never run against a real `.xcresult`. The specific risk is the exact names `xccov` reports targets under in a *workspace-wide* bundle — if one differs, `Emit coverage figures` warns and no recording happens. That is why the step is `continue-on-error` and why the refusal is all-or-nothing: the failure mode is visibly-absent numbers, never silently-wrong ones.

## Two things to decide

1. **`main` is protected.** If its rules do not let the Actions bot push, the first recording will warn instead of landing, with the diff in the job summary. Either allow the bot to bypass for this path, or say the word and I will convert the job to open a PR instead.
2. **The badges still read `not measured` in this diff**, deliberately — the first real figures land when this workflow next runs on `main` after merge. I could not fill them in here, for the reasons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YGPVWp1m66uAs1Lh2zKKT

---
_Generated by [Claude Code](https://claude.ai/code/session_019YGPVWp1m66uAs1Lh2zKKT)_