### PR TITLE
Record the measured coverage, and propose future updates by pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,12 @@ jobs:
   # markers — the thing both badges spent this repository's whole history saying `not measured` for
   # while the number was being computed on every run and thrown away with the runner.
   #
+  # It **proposes** that edit as a pull request rather than committing it. The first version of this
+  # job pushed straight to `main` and was refused — `GH006: Protected branch update failed`,
+  # "Changes must be made through a pull request", "2 of 2 required status checks are expected" —
+  # which is the branch protection working, not a fault to route around. The step at the bottom
+  # explains what proposing rather than pushing changes about the commit it makes.
+  #
   # Why this is a separate job on Linux rather than three more lines on the macOS one is argued at
   # `Emit coverage figures` above: `contents: write` must not sit on the job that compiles and runs
   # code out of a pull request. What runs here is one stdlib Python script over one Markdown file.
@@ -593,15 +599,19 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
+      # `contents` to push the coverage branch, `pull-requests` to open the request against it.
+      # Both are scoped to this job — the workflow-level default above stays read-only, which is
+      # what the macOS job runs under.
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # `main` rather than the pushed SHA, because the number goes where a reader will look for
-          # it. `fetch-depth: 0` because the push at the end may have to rebase onto a tip that
-          # moved while the macOS job was still running, and a depth-1 clone has nothing to rebase
-          # onto.
+          # `main` rather than the pushed SHA: the coverage branch has to branch from the tip a
+          # reader will merge it into, not from whichever commit was measured. `fetch-depth: 0`
+          # because the branch below is force-pushed, and a push out of a shallow clone is refused
+          # with "shallow update not allowed".
           ref: main
           fetch-depth: 0
 
@@ -624,13 +634,34 @@ jobs:
           printf '%s\n' "$COVERAGE_JSON" > .artifacts/coverage/coverage.json
           echo "state=ready" >> "$GITHUB_OUTPUT"
 
-      # `main` is a protected branch. Whether these rules let this token push is a repository
-      # setting rather than anything a commit can fix, so a rejection must not redden a commit whose
-      # tests all passed: the step warns, and puts the diff it wanted to make into the job summary
-      # where somebody can apply it by hand. The number is never lost, at worst it is not committed.
-      - name: Record it in README.md
+      # `main` is a protected branch — "Changes must be made through a pull request", plus two
+      # required status checks — so this job proposes the update instead of pushing it. That is not
+      # a workaround bolted on after a rejection; it is the same rule every other change here goes
+      # through, and it means recorded figures get reviewed like anything else.
+      #
+      # Three consequences worth knowing before editing this step:
+      #
+      #   - **The commit must NOT carry a skip-CI marker.** A direct push to `main` needed one, or it
+      #     would trigger the workflow that wrote it. A pull request needs the opposite: protection
+      #     requires two status checks, and a commit that skips CI produces none, so the request
+      #     could never become mergeable. Different destination, opposite requirement.
+      #   - **A fixed branch, force-pushed.** One long-lived coverage request that updates in place,
+      #     rather than a new one per push to `main`. Pushing the branch triggers nothing by itself —
+      #     this workflow's `push` trigger is `main`-only — so opening or updating the request is
+      #     what runs the checks.
+      #   - **It converges.** Merging the coverage request is itself a push to `main`, which measures
+      #     again; but editing the README cannot change what the tests cover, so that measurement is
+      #     identical, `git diff --quiet` finds nothing, and no second request is opened.
+      #
+      # Still `continue-on-error`. Opening a pull request from Actions additionally requires
+      # "Allow GitHub Actions to create and approve pull requests" in the repository settings, and a
+      # settings answer must never redden a commit whose tests all passed.
+      - name: Propose the update as a pull request
         if: steps.figures.outputs.state == 'ready'
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: automation/record-coverage
         run: |
           set -euo pipefail
 
@@ -639,43 +670,41 @@ jobs:
             --readme README.md
 
           # The generated block is a pure function of the figures — no timestamp, no run URL — so an
-          # unchanged measurement leaves the file byte-identical and there is nothing to commit.
-          # Without that property `main` would grow one commit per push forever.
+          # unchanged measurement leaves the file byte-identical and there is nothing to propose.
+          # This is what stops a pull request being opened on every push to `main`.
           if git diff --quiet -- README.md; then
-            echo "README.md already records these figures — nothing to commit."
+            echo "README.md already records these figures — nothing to propose."
             exit 0
           fi
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B "$BRANCH"
           git add README.md
-          # `[skip ci]` is load-bearing: without it this commit triggers the workflow that wrote it.
-          git commit -m 'docs: record measured coverage in the README [skip ci]'
+          git commit -m 'docs: record measured coverage in the README'
+          git push --force origin "$BRANCH"
 
-          if git push origin HEAD:main; then
-            echo "Recorded."
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "Existing coverage pull request updated in place."
             exit 0
           fi
 
-          # A push can also simply lose a race — `main` moved while the macOS job was running. That
-          # is worth exactly one rebase before concluding the branch rules are what rejected it.
-          echo "Push rejected; rebasing onto main and trying once more."
-          if git pull --rebase origin main && git push origin HEAD:main; then
-            echo "Recorded after a rebase."
-            exit 0
-          fi
+          # printf rather than a heredoc: a heredoc body would carry this block's own indentation
+          # into the Markdown, and ten leading spaces is a code fence.
+          printf '%s\n' \
+            'Recorded by the `record-coverage` job, from the coverage the macOS job measured on `main`.' \
+            '' \
+            'This file is generated. The two badges and the `coverage:generated` block are written by' \
+            '`Scripts/update_readme_coverage.py`, and that block is a pure function of the measured' \
+            'figures — so this request exists only because a number moved. Merging it is itself a push' \
+            'to `main`, which measures again and finds nothing left to change.' \
+            '' \
+            '---' \
+            '_Generated by [Claude Code](https://claude.ai/code)_' \
+            > "$RUNNER_TEMP/coverage-pr-body.md"
 
-          echo "::warning::Could not push the coverage update to main — the diff is in the job summary."
-          patch="$(git diff 'HEAD^' HEAD -- README.md || true)"
-          {
-            echo '### Coverage measured, but not recorded'
-            echo
-            echo 'The push to `main` was rejected. If branch protection is what refused it, either'
-            echo 'allow the Actions bot to bypass the rule for this path, or apply the diff below by'
-            echo 'hand. The figures themselves are in the macOS job'"'"'s summary and its job output.'
-            echo
-            echo '```diff'
-            printf '%s\n' "$patch"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 1
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title 'docs: record measured coverage in the README' \
+            --body-file "$RUNNER_TEMP/coverage-pr-body.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,11 +97,13 @@ xcodebuild -workspace Mimic.xcworkspace -list      # every scheme Tuist actually
 
 CI runs on every pull request and on every push to `main`, in three jobs. Two are split by what
 actually needs a Mac; the third, `record-coverage`, is a short Linux job that runs only on pushes to
-`main` and writes the coverage the macOS job measured into the README's two badges and its
-`coverage:generated` block. It is the only job in the workflow holding `contents: write`, and it
-holds it precisely so that the job compiling code out of a pull request does not — see the comments
-above it and above `Emit coverage figures`. Both runners are free: GitHub does not meter standard
-hosted runners on public repositories, macOS included.
+`main` and opens a pull request recording the coverage the macOS job measured into the README's two
+badges and its `coverage:generated` block. It is the only job in the workflow that can write, and it
+is separate precisely so that the job compiling code out of a pull request cannot — see the comments
+above it and above `Emit coverage figures`. It proposes rather than pushes because `main` is
+protected: pushing directly was tried and refused with `GH006 — Changes must be made through a pull
+request`, so the job now goes through protection like every other change. Both runners are free:
+GitHub does not meter standard hosted runners on public repositories, macOS included.
 
 **Linux** builds through [`Package.swift`](Package.swift) rather than Tuist — the domain rules, mock
 engine, persistence, control plane, spec import and CLI are plain Swift, so most of the suite reports

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ failures, and watch live traffic. Then drive all of it from a script.
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
 [![Tests](https://img.shields.io/badge/tests-988%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
-[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
+[![Coverage](https://img.shields.io/badge/coverage-88.97%25-yellow)](#coverage)
+[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-5%2F8-red)](#coverage)
 
 [Install](#install) · [Quickstart](#quickstart) · [Journeys](#journeys) · [CLI](docs/CLI.md) · [Architecture](docs/ARCHITECTURE.md)
 
@@ -326,29 +326,34 @@ structurally: XCUITest, because the step doing the measuring is the one that ski
 the Linux job runs, because gathering coverage needs the Xcode toolchain. On a red run the bundle is
 uploaded as the `xcresult` artifact, which is where per-file detail lives.
 
-**The numbers are also recorded here, on every push to `main`.** They used to exist only in that job
-summary — computed on every run and thrown away with the runner — which is why both badges above
-spent this repository's entire history reading `not measured` while the measurement was already
-happening. The `record-coverage` job closes that: the macOS job hands its figures on as a job
-output, and that job rewrites the two badges and the block below with
-[`Scripts/update_readme_coverage.py`](Scripts/update_readme_coverage.py).
+**The numbers are recorded here too, proposed on every push to `main`.** They used to exist only in
+that job summary — computed on every run and thrown away with the runner — which is why both badges
+above spent this repository's entire history reading `not measured` while the measurement was
+already happening. The `record-coverage` job closes that: the macOS job hands its figures on as a
+job output, and that job rewrites the two badges and the block below with
+[`Scripts/update_readme_coverage.py`](Scripts/update_readme_coverage.py), then opens a pull request
+with the result.
 
 Four things about it are deliberate, and each is the answer to a way this normally goes wrong:
 
-- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS job
-  compiles and runs code out of a pull request; a write token there would widen the blast radius of
-  anything going wrong in it to "can push to `main`". The recording job runs one Python script over
-  one Markdown file.
+- **It is a separate job, and the only one in the workflow that can write.** The macOS job compiles
+  and runs code out of a pull request; a write token there would widen the blast radius of anything
+  going wrong in it to "can push to `main`". The recording job runs one Python script over one
+  Markdown file.
 - **A few hundred bytes cross between them, not the bundle.** The `.xcresult` is hundreds of
   megabytes and stays on the runner that made it.
 - **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
   coverage figures, so an unchanged measurement leaves the file byte-identical and there is nothing
-  to commit — otherwise `main` would collect one commit per push forever. The commit that is made
-  carries `[skip ci]`, or it would trigger the workflow that wrote it.
-- **It records; it never gates.** `main` is a protected branch, and whether its rules let the Actions
-  bot push is a repository setting rather than something a commit can fix. A rejected push warns and
-  prints the diff it wanted to make into the job summary — it never reddens a commit whose tests
-  passed.
+  to propose — otherwise a pull request would open on every push forever. It also means the flow
+  converges: merging one is itself a push to `main`, which measures again and finds nothing left to
+  change, because editing this file cannot change what the tests cover.
+- **It proposes rather than pushes, because `main` is protected.** The first version of this job
+  pushed directly and was refused — *"Changes must be made through a pull request"*, plus two
+  required status checks. That is the protection working, so the job now goes through it like every
+  other change, on a fixed branch that updates in place. One consequence is worth knowing before
+  editing the step: the commit must **not** carry `[skip ci]`. Pushing to `main` needed it, or the
+  commit would trigger the workflow that wrote it; a pull request needs the opposite, since a commit
+  that skips CI produces none of the required checks and could never be merged.
 
 A Mac still writes the same section from a full local suite, out of the per-scheme bundles rather
 than the workspace-wide one, and the generated block says which of the two produced it:
@@ -360,20 +365,44 @@ than the workspace-wide one, and the generated block says which of the two produ
 
 The half of that script needing no Mac — the rewriting, the JSON hand-off and the refusals — is
 covered by `python3 Scripts/update_readme_coverage.py --self-test`, which the Linux job runs beside
-the other checkers. It had no automated test of any kind before it started writing to `main`.
+the other checkers. It had no automated test of any kind before it started writing this file.
 
 **No coverage floor is enforced, deliberately.** A threshold picked before anybody has seen the
 number is either so low it never fires or red on the run that introduces it. Measuring first, then
 setting the floor against a baseline, is the order.
 
 <!-- coverage:generated:start -->
+This section is auto-generated — do not edit it by hand. It is written by CI on every push to `main`, from the workspace-wide unit run the macOS job measures with `-enableCodeCoverage YES`.
+
+Latest measured line coverage:
+
+| Target | Coverage | Lines |
+| --- | ---: | ---: |
+| `Mimic.app` | `46.67%` | `28/60` |
+| `Domain.framework` | `95.99%` | `2,274/2,369` |
+| `MockServerEngine.framework` | `96.88%` | `341/352` |
+| `Persistence.framework` | `98.12%` | `992/1,011` |
+| `DesignSystem.framework` | `96.34%` | `2,474/2,568` |
+| `SpecImport.framework` | `97.23%` | `1,088/1,119` |
+| `ControlPlane.framework` | `86.36%` | `342/396` |
+| `MimicCLICore.framework` | `86.72%` | `1,260/1,453` |
+| `AppFeatures.framework` | `85.97%` | `14,344/16,685` |
+
+Coverage notes:
+
+- Every target above, weighted by executable lines: `88.97%` (`23,143/26,013`). This is what the headline badge shows.
+- Modules at or above `95%`: `5/8`.
+- `Mimic.app` is the `@main` shell — `60` executable lines in all — so read its row as a footnote rather than a summary. The app's behaviour lives in `AppFeatures.framework`.
+- `Lines` shows covered/executable lines reported by `xcrun xccov`.
+- Coverage is gathered with `xcodebuild` and `xcrun xccov` from fresh `.xcresult` bundles.
+- XCUITest is not in these figures: the step that measures coverage is the one passing `-skip-testing:MimicUITests`, and the Linux job gathers no coverage at all. No floor is enforced against them — this records, it does not gate.
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
 `main`, in three jobs: Linux builds `Package.swift` and runs the portable suites in a couple of
 minutes, macOS runs `tuist generate`, the Debug build, the app-level suites — measured, with the
 per-target coverage table printed into the job summary — XCUITest and the Release gate, and a short
-`record-coverage` job writes those figures into this file on pushes to `main`. Both runners
+`record-coverage` job proposes those figures into this file on pushes to `main`. Both runners
 are free on a public repository. (This section used to say Actions could not start
 a job here at all — true while the repository was private and a billing block killed every run in
 about two seconds; making it public resolved it.)

--- a/Scripts/update_readme_coverage.py
+++ b/Scripts/update_readme_coverage.py
@@ -174,6 +174,30 @@ def format_lines(metrics: CoverageMetrics) -> str:
     return f"{metrics.covered_lines:,}/{metrics.executable_lines:,}"
 
 
+def overall_metrics(
+    app_metrics: CoverageMetrics, module_metrics: list[tuple[str, CoverageMetrics]]
+) -> CoverageMetrics:
+    """Every measured target as one figure, weighted by executable lines.
+
+    This is what the headline badge shows, and the reason is `Mimic.app`, which used to have that
+    job: it is the `@main` shell and measures **60 executable lines**, so it swings on a couple of
+    them and describes almost nothing. The app's actual behaviour lives in `AppFeatures.framework`,
+    16,685 lines of it. A badge that reads `Mimic.app coverage 46.67%` beside a tree measuring 89%
+    is not wrong, it is just answering a question nobody asked.
+
+    Averaging the percentages would be the other mistake — that weights a 60-line target the same as
+    a 16,685-line one. Summing the lines first is the only figure that means "of the code this
+    measures, how much runs".
+    """
+    covered = app_metrics.covered_lines + sum(m.covered_lines for _, m in module_metrics)
+    executable = app_metrics.executable_lines + sum(m.executable_lines for _, m in module_metrics)
+    if executable == 0:
+        raise RuntimeError("the report has no executable lines in it at all")
+    return CoverageMetrics(
+        percent=100.0 * covered / executable, covered_lines=covered, executable_lines=executable
+    )
+
+
 def build_coverage_block(
     app_metrics: CoverageMetrics,
     module_metrics: list[tuple[str, CoverageMetrics]],
@@ -196,15 +220,18 @@ def build_coverage_block(
         lines.append(f"| `{target_name}` | `{format_percent(metrics.percent)}` | `{format_lines(metrics)}` |")
 
     modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
-    total_executable_lines = app_metrics.executable_lines + sum(metrics.executable_lines for _, metrics in module_metrics)
+    overall = overall_metrics(app_metrics, module_metrics)
     lines.extend(
         [
             "",
             "Coverage notes:",
             "",
-            f"- App coverage is currently `{format_percent(app_metrics.percent)}`.",
+            f"- Every target above, weighted by executable lines: `{format_percent(overall.percent)}` "
+            f"(`{format_lines(overall)}`). This is what the headline badge shows.",
             f"- Modules at or above `95%`: `{modules_at_or_above_95}/{len(module_metrics)}`.",
-            f"- Total executable lines tracked in this table: `{total_executable_lines:,}`.",
+            f"- `Mimic.app` is the `@main` shell — `{app_metrics.executable_lines:,}` executable lines "
+            "in all — so read its row as a footnote rather than a summary. The app's behaviour lives "
+            "in `AppFeatures.framework`.",
             "- `Lines` shows covered/executable lines reported by `xcrun xccov`.",
             "- Coverage is gathered with `xcodebuild` and `xcrun xccov` from fresh `.xcresult` bundles.",
             f"- {provenance}",
@@ -266,10 +293,15 @@ def replace_coverage_block(readme: str, new_block: str) -> str:
     return pattern.sub(new_block, readme, count=1)
 
 
-def replace_badges(readme: str, app_percent: float, modules_at_or_above_95: int, module_count: int) -> str:
-    app_badge = (
-        f"[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-"
-        f"{app_percent:.2f}%25-{badge_color(app_percent)})](#coverage)"
+def replace_badges(readme: str, overall_percent: float, modules_at_or_above_95: int, module_count: int) -> str:
+    # `Coverage`, not `App Coverage`: the headline figure is every measured target weighted by
+    # executable lines, because the badge used to read `Mimic.app coverage` off a 60-line `@main`
+    # shell. See `overall_metrics` for the argument. The alt text is part of the contract — the
+    # pattern below is what finds the badge to replace — so changing one means changing both, and
+    # the self-test fixture carries the same spelling for that reason.
+    overall_badge = (
+        f"[![Coverage](https://img.shields.io/badge/coverage-"
+        f"{overall_percent:.2f}%25-{badge_color(overall_percent)})](#coverage)"
     )
     modules_badge = (
         "[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-"
@@ -280,9 +312,9 @@ def replace_badges(readme: str, app_percent: float, modules_at_or_above_95: int,
     # carried no coverage badges at all this function was a guaranteed silent no-op: the full suite
     # ran, the script exited 0, `run_full_test_suite.sh` printed "README coverage section updated."
     # and neither badge had ever existed. `replace_coverage_block` above defends itself; this did not.
-    readme, replaced = re.subn(r"\[!\[App Coverage\]\([^)]+\)\]\(#coverage\)", app_badge, readme, count=1)
+    readme, replaced = re.subn(r"\[!\[Coverage\]\([^)]+\)\]\(#coverage\)", overall_badge, readme, count=1)
     if replaced != 1:
-        raise RuntimeError("README.md is missing the App Coverage badge.")
+        raise RuntimeError("README.md is missing the Coverage badge.")
     readme, replaced = re.subn(r"\[!\[Module Coverage\]\([^)]+\)\]\(#coverage\)", modules_badge, readme, count=1)
     if replaced != 1:
         raise RuntimeError("README.md is missing the Module Coverage badge.")
@@ -350,7 +382,8 @@ def render_readme(
 ) -> str:
     """The whole rewrite as a string function, so `--self-test` can check it without touching disk."""
     modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
-    readme = replace_badges(readme, app_metrics.percent, modules_at_or_above_95, len(module_metrics))
+    overall = overall_metrics(app_metrics, module_metrics)
+    readme = replace_badges(readme, overall.percent, modules_at_or_above_95, len(module_metrics))
     return replace_coverage_block(
         readme,
         build_coverage_block(
@@ -466,7 +499,7 @@ def update_readme_from_json(readme_path: Path, json_path: Path) -> None:
 
 FIXTURE_README = """# Fixture
 
-[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
+[![Coverage](https://img.shields.io/badge/coverage-not%20measured-lightgrey)](#coverage)
 [![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
 
 Prose that must survive untouched.
@@ -493,17 +526,27 @@ def self_test() -> int:
         if not condition:
             failures.append(message)
 
-    app = CoverageMetrics(percent=41.5, covered_lines=1_000, executable_lines=2_409)
+    # Deliberately lopsided: a tiny, badly covered app shell beside a large, well covered module,
+    # which is the shape the real tree has. It is what distinguishes the weighted figure the badge
+    # now shows (2,281/3,809 = 59.88%) from the mean of the three percentages (~72%) and from the
+    # app's own 41.50% that the badge used to lead with. All three differ, so a regression to either
+    # of the wrong two fails here.
+    app = CoverageMetrics(percent=41.50, covered_lines=1_000, executable_lines=2_409)
     modules = [
         ("Domain.framework", CoverageMetrics(percent=96.0, covered_lines=960, executable_lines=1_000)),
         ("ControlPlane.framework", CoverageMetrics(percent=80.25, covered_lines=321, executable_lines=400)),
     ]
+    check(
+        abs(overall_metrics(app, modules).percent - 59.88) < 0.01,
+        "the weighted overall figure is not what the fixture's lines add up to",
+    )
 
     rendered = render_readme(
         FIXTURE_README, app, modules, generated_from="From a fixture.", provenance="Fixture note."
     )
     check("not%20measured" not in rendered, "a badge still reads 'not measured' after a rewrite")
-    check("41.50%25" in rendered, "the app badge does not carry the measured percentage")
+    check("badge/coverage-59.88%25" in rendered, "the headline badge does not carry the weighted figure")
+    check("41.50%25" not in rendered, "the headline badge still leads with the app shell's own figure")
     check("1%2F2" in rendered, "the module badge does not carry the at-or-above-95 count")
     check("`Domain.framework` | `96.00%` | `960/1,000`" in rendered, "a module row is missing or misformatted")
     check("Prose that must survive untouched." in rendered, "prose outside the markers was lost")
@@ -532,7 +575,7 @@ def self_test() -> int:
         )
         update_readme_from_json(readme_path, json_path)
         from_json = readme_path.read_text()
-        check("41.50%25" in from_json, "--from-json did not rewrite the app badge")
+        check("badge/coverage-59.88%25" in from_json, "--from-json did not rewrite the headline badge")
         check(CI_PROVENANCE in from_json, "--from-json did not use the CI provenance wording")
 
         json_path.write_text("{\"app\": {}}")


### PR DESCRIPTION
Two follow-ups to #54, now that its first real run has happened.

## The figures are in

The macOS job measured them on `main` (run [31822317550](https://github.com/srpadrono/mimic/actions/runs/31822317550)), and `--emit-json` read the workspace-wide bundle without trouble — every target reported under exactly the name the script expected, which was the one thing about #54 that could not be checked before it ran.

| Target | Coverage | Lines |
| --- | ---: | ---: |
| `Persistence.framework` | 98.12% | 992/1,011 |
| `SpecImport.framework` | 97.23% | 1,088/1,119 |
| `MockServerEngine.framework` | 96.88% | 341/352 |
| `DesignSystem.framework` | 96.34% | 2,474/2,568 |
| `Domain.framework` | 95.99% | 2,274/2,369 |
| `MimicCLICore.framework` | 86.72% | 1,260/1,453 |
| `ControlPlane.framework` | 86.36% | 342/396 |
| `AppFeatures.framework` | 85.97% | 14,344/16,685 |
| `Mimic.app` | 46.67% | 28/60 |

**All nine weighted by executable lines: 88.97% (23,143/26,013). Five of eight modules at or above 95%.**

## The recording job proposes rather than pushes

Its push was refused:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

That is the branch protection working, not a fault to route around, so the job now goes through it: a fixed branch (`automation/record-coverage`), force-pushed, with one long-lived pull request that updates in place rather than a new one per push.

One consequence is easy to get backwards, and is commented at the step: **the commit must not carry a skip-CI marker.** Pushing to `main` needed one or the commit would trigger the workflow that wrote it — a pull request needs the opposite, because a commit that skips CI produces none of the two required checks and could never be merged. Same marker, opposite requirement, decided by the destination.

It still converges. Merging the coverage request is itself a push to `main`, which measures again — but editing the README cannot change what the tests cover, so the measurement is identical, `git diff --quiet` finds nothing, and no second request opens.

`pull-requests: write` joins `contents: write`, both scoped to that job alone. The workflow default stays read-only, which is what the macOS job runs under.

## The headline badge is the weighted total

`Mimic.app` is the `@main` shell and measures **sixty executable lines**, so it swings on a couple of them and describes almost nothing. Left as the headline it would have led the README with `Mimic.app coverage 46.67%` beside a tree measuring 89%. The app's behaviour is in `AppFeatures.framework`, 16,685 lines of it.

Averaging the per-target percentages would be the other mistake — that weights a 60-line target the same as a 16,685-line one — so the lines are summed first. The `Mimic.app` row stays in the table, with a note telling a reader to treat it as a footnote rather than a summary.

The self-test fixture is now deliberately lopsided (a small badly covered shell beside a large well covered module) so that the weighted figure, the mean of the percentages, and the app's own number are three different values. A regression to either of the wrong two fails.

## Verification

Every Linux gate passes locally, including the coverage writer self-test. The workflow parses, its `run` block passes `bash -n`, the generated PR body was rendered and checked for stray indentation (ten leading spaces would have made it a code fence — hence `printf` rather than a heredoc), and the commit message carries no skip-CI marker, which is what silenced CI on the first push of #54.

**Not verified:** whether `gh pr create` is permitted. That needs *Allow GitHub Actions to create and approve pull requests* in repository settings. If it is off, the step warns and the run stays green, but no coverage request appears — worth checking before the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YGPVWp1m66uAs1Lh2zKKT

---
_Generated by [Claude Code](https://claude.ai/code/session_019YGPVWp1m66uAs1Lh2zKKT)_