### PR TITLE
Shard the UI suite across three runners: CI 96 min → 33 min, measured

### DIFF
--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -1,15 +1,15 @@
 # What CI actually covers
 
-CI runs on every pull request and on every push to `main`, in **five job definitions and eight
-jobs** — the UI one is a four-leg matrix. Both runners are free: GitHub does not meter standard
+CI runs on every pull request and on every push to `main`, in **five job definitions and seven
+jobs** — the UI one is a three-leg matrix. Both runners are free: GitHub does not meter standard
 hosted runners on public repositories, macOS included.
 
 | Job | Runner | Covers |
 |-----|--------|--------|
 | `linux` | `ubuntu-latest`, `swift:6.2` | `Package.swift`, the portable suites, and every cheap gate: house rules, the three manifest checks, documented counts, skill layout, UI-shard coverage, the coverage-writer self-test |
 | `macos-checks` | `macos-26` | `tuist generate`, the Debug build, the app-level suites **with the coverage measurement**, the CLI end-to-end check (non-gating), the Release gate and its warning inventory |
-| `macos-ui` (×4) | `macos-26` | The XCUITest suite, sharded across four runners by test class |
-| `ui-suite` | `ubuntu-latest` | Rolls the four shard results into one status check |
+| `macos-ui` (×3) | `macos-26` | The XCUITest suite, sharded across three runners by test class |
+| `ui-suite` | `ubuntu-latest` | Rolls the three shard results into one status check |
 | `record-coverage` | `ubuntu-latest` | Pushes to `main` only: writes the measured coverage into README.md |
 
 `record-coverage` is the only job holding `contents: write`, and it holds it precisely so that the
@@ -24,8 +24,26 @@ flake happened not to fire.
 There used to be one macOS job running strictly in sequence, and run #87 measured it at about **96
 minutes**, of which XCUITest alone was about **80**. The Release gate and the end-to-end check sat
 behind the UI suite for no reason at all. Splitting the non-UI work out and sharding the UI suite
-brings a run to about **29 minutes**, with the first red — a compile break or a unit failure — inside
+brings a run to about **30 minutes**, with the first red — a compile break or a unit failure — inside
 ten.
+
+Measured, rather than predicted. Run #89 (62b80e7) was the first real run of the sharded workflow,
+with four shards:
+
+| Job | Run #89, four shards | Now, three shards |
+|-----|---------------------:|------------------:|
+| `linux` | 2m20 | ~2m20 |
+| `macos-checks` | 19m43 | ~19m43 |
+| UI shard 1 | 21m18 (40 tests) | ~28m (51 tests) |
+| UI shard 2 | 19m23 (38 tests) | ~29m (53 tests) |
+| UI shard 3 | 23m49 (39 tests) | ~30m (54 tests) |
+| UI shard 4 | **queued 19m26**, then ~22m (41 tests) | — |
+| **Wall clock** | **~43m** | **~30m** |
+
+The saving is not from running less — it is the same 158 tests — it is from stopping asking for a
+fifth concurrent macOS job. Shard 3's 39 tests in a 22m42 step that also contains the build and the
+test-target compile give the constant the right-hand column is derived from: **about 26 seconds per
+UI test**.
 
 Three things about the split are load-bearing, and the workflow's header argues each at length:
 
@@ -38,15 +56,23 @@ Three things about the split are load-bearing, and the workflow's header argues 
   `typeText`, `typeKey` and ⌘-click, which go to whichever app has focus. Separate machines dissolve
   both. Nothing in `MimicUITests` needed changing — the suites already use disjoint port ranges and
   already suffix `MIMIC_CONTROL_FILE` with the runner's pid.
-- **Five macOS jobs, because GitHub caps concurrent macOS jobs at five** on Free, Pro and Team (50 on
-  Enterprise Cloud) — a much smaller cap than the 20/40/60 on standard runners. Exceeding it queues
-  rather than fails, and a queued shard lands at roughly twice the shard time, so five is a budget:
-  one `macos-checks` plus four shards. That is also why the Release gate is not a job of its own —
-  it would cost a shard slot and lengthen the run.
+- **Four macOS jobs, because four is the concurrency this repository was observed to get.** GitHub
+  *documents* the concurrent-macOS-job cap as five on Free, Pro and Team (50 on Enterprise Cloud) — a
+  much smaller cap than the 20/40/60 on standard runners — and the workflow was first written against
+  that five: one `macos-checks` plus four shards. **Run #89 ran four.** Four jobs started together at
+  22:01:49; the fifth started 19m26 later, two seconds after the first one finished and freed a slot.
+  Exceeding the cap queues rather than fails, and a queued shard lands at roughly twice the shard
+  time, which is exactly what happened. The claim worth carrying forward is the observation and not
+  the documentation: **documented five, observed four, and a fifth macOS job waits about a shard's
+  length.** The documented figure may be right in general and wrong for this account or this runner
+  pool; one run is enough to design against and not enough to call the docs wrong. Before adding a
+  fifth macOS job — another shard, or the Release gate split out of `macos-checks` — expect it to
+  queue, and bring a measurement rather than the documented number. That is also why the Release gate
+  is not a job of its own: it would cost a shard slot and lengthen the run.
 - **Each shard builds for itself** rather than downloading products from a shared
   `build-for-testing` job. The shards run concurrently, so the ~5-minute Debug build was never on the
   critical path more than once; building once would move it onto a *serial* job ahead of every shard
-  and add a tar, an upload and four downloads. Build-once saves runner minutes, which this repository
+  and add a tar, an upload and three downloads. Build-once saves runner minutes, which this repository
   is not billed for, and risks a code signature that does not survive the round trip — which presents
   as a broken suite, not a broken artifact.
 
@@ -59,10 +85,14 @@ shard naming a class that no longer exists (which `xcodebuild` reports as "no te
 It reads the workflow as text and `MimicUITests/` as text — no PyYAML, because the Linux container
 installs `python3-minimal`.
 
-Today's split is 40 / 38 / 39 / 41 across the ten classes, balanced longest-first by **test count**,
-which is a proxy for time rather than time itself — a defensible one, since nearly every test launches
-the app and per-test cost is dominated by launch. To rebalance from real data, take a shard's
-`xcresult-ui-N` artifact and read the per-test durations out of it:
+Today's split is **51 / 53 / 54** across the ten classes, against an ideal third of 52.7, balanced by
+**test count** — a proxy for time rather than time itself, and a defensible one since nearly every
+test launches the app and per-test cost is dominated by launch. Run #89 supports the proxy without
+vindicating it: 40 / 38 / 39 tests took 21m18 / 19m23 / 23m49, so the ordering does not track the
+counts exactly, but the spread is small. An exhaustive search of every way of dealing the ten classes
+onto three shards puts the best achievable spread at 2 (52 / 52 / 54); this split takes 3 and spends
+the extra test — about 26 seconds — on shards whose names describe what they run. To rebalance from
+real data, take a shard's `xcresult-ui-N` artifact and read the per-test durations out of it:
 
 ```bash
 xcrun xcresulttool get test-results tests --path UITests.xcresult
@@ -102,15 +132,15 @@ its own the day `swiftSettings:` lands.
 **macOS** (`macos-26`) covers everything that needs Xcode, across two job definitions that run at the
 same time. `macos-checks` does `tuist generate`, the Debug build, the app-level suites, the CLI
 end-to-end check — non-gating, for the reason below — and the Release gate. `macos-ui` does **the
-XCUITest suite**, in four shards. The image label is load-bearing on both — macOS 26 and Swift 6.2
+XCUITest suite**, in three shards. The image label is load-bearing on both — macOS 26 and Swift 6.2
 are the compile floor, not a preference.
 
 Four things about the macOS jobs are worth knowing before you edit them:
 
-- **The setup lives in a composite action.** `.github/actions/macos-setup` holds what all five macOS
+- **The setup lives in a composite action.** `.github/actions/macos-setup` holds what all four macOS
   jobs do before they build: Xcode and Swift versions, `automationmodetool`, Tuist at the pinned
   `mise.toml` version, its dependency cache, the `Tuist/Package.resolved` drift check, and `tuist
-  generate`. Five pasted copies of those seven steps and their comments is the duplication AGENTS.md
+  generate`. Four pasted copies of those seven steps and their comments is the duplication AGENTS.md
   names outright. Two constraints when editing it: every `run:` step needs an explicit `shell: bash`,
   and `continue-on-error:` is a workflow-level key that composite steps do not take — end a
   diagnostic in `|| true` instead.
@@ -118,7 +148,7 @@ Four things about the macOS jobs are worth knowing before you edit them:
   the build log first (an xcresult cannot carry one — a test target that fails to build produces a
   bundle with `totalTestCount: 0`), then every failure with its message, file and line out of the
   newest bundle it was handed. Both test-running job kinds call it on `failure()`, which is why it is
-  a script rather than forty lines of embedded Python pasted five times. It always exits 0.
+  a script rather than forty lines of embedded Python pasted four times. It always exits 0.
 
 - **`sudo automationmodetool enable-automationmode-without-authentication` is what makes XCUITest
   possible at all.** Since Monterey, macOS asks a human to approve UI automation before a runner may
@@ -145,7 +175,7 @@ compiles, `check_module_edges.py` among them, because a drift there makes every 
 build that does not ship. Its own header names the four things it cannot reproduce — `swift test`
 runs on this machine's toolchain rather than in the `swift:6.2` container, the UI suite runs without
 CI's `-retry-tests-on-failure`, runner setup is absent, and **the UI suite runs in one pass on one
-machine rather than in four shards on four**, which is both why it takes about eighty minutes here
-against CI's twenty-nine and why `check_ui_shards.py` is the only thing that can see a missing shard
+machine rather than in three shards on three**, which is both why it takes about eighty minutes here
+against CI's thirty and why `check_ui_shards.py` is the only thing that can see a missing shard
 entry from a laptop. Read it rather than treating a green local run as a green CI run.
 

--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -1,12 +1,78 @@
 # What CI actually covers
 
-CI runs on every pull request and on every push to `main`, in three jobs. Two are split by what
-actually needs a Mac; the third, `record-coverage`, is a short Linux job that runs only on pushes to
-`main` and writes the coverage the macOS job measured into the README's two badges and its
-`coverage:generated` block. It is the only job in the workflow holding `contents: write`, and it
-holds it precisely so that the job compiling code out of a pull request does not — see the comments
-above it and above `Emit coverage figures`. Both runners are free: GitHub does not meter standard
+CI runs on every pull request and on every push to `main`, in **five job definitions and eight
+jobs** — the UI one is a four-leg matrix. Both runners are free: GitHub does not meter standard
 hosted runners on public repositories, macOS included.
+
+| Job | Runner | Covers |
+|-----|--------|--------|
+| `linux` | `ubuntu-latest`, `swift:6.2` | `Package.swift`, the portable suites, and every cheap gate: house rules, the three manifest checks, documented counts, skill layout, UI-shard coverage, the coverage-writer self-test |
+| `macos-checks` | `macos-26` | `tuist generate`, the Debug build, the app-level suites **with the coverage measurement**, the CLI end-to-end check (non-gating), the Release gate and its warning inventory |
+| `macos-ui` (×4) | `macos-26` | The XCUITest suite, sharded across four runners by test class |
+| `ui-suite` | `ubuntu-latest` | Rolls the four shard results into one status check |
+| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: writes the measured coverage into README.md |
+
+`record-coverage` is the only job holding `contents: write`, and it holds it precisely so that the
+jobs compiling code out of a pull request do not — see the comments above it and above `Emit coverage
+figures`. It needs `macos-checks` and **not** the UI shards, because coverage is measured in that job
+and because this repository's UI suite is documented as ending red on a test that passed on its
+retry; making the recording wait on the shards would mean the README updates only on runs where a
+flake happened not to fire.
+
+## Why the macOS work is split the way it is
+
+There used to be one macOS job running strictly in sequence, and run #87 measured it at about **96
+minutes**, of which XCUITest alone was about **80**. The Release gate and the end-to-end check sat
+behind the UI suite for no reason at all. Splitting the non-UI work out and sharding the UI suite
+brings a run to about **29 minutes**, with the first red — a compile break or a unit failure — inside
+ten.
+
+Three things about the split are load-bearing, and the workflow's header argues each at length:
+
+- **Shards, never `-parallel-testing-enabled`.** Two independent reasons, either of which is
+  sufficient. The suites share one store (`UITestSupport.databaseURL` is the fixed
+  `mimic-uitests.sqlite`, and `resetApp` deletes it on every launch) and one defaults domain (the
+  fixed `com.devxa.Mimic.UITests`, wiped in `setUpWithError`), so two workers on one machine destroy
+  each other's state by construction. And this is a real macOS app rather than a simulator: parallel
+  workers share one window server and one frontmost application, while these suites lean on
+  `typeText`, `typeKey` and ⌘-click, which go to whichever app has focus. Separate machines dissolve
+  both. Nothing in `MimicUITests` needed changing — the suites already use disjoint port ranges and
+  already suffix `MIMIC_CONTROL_FILE` with the runner's pid.
+- **Five macOS jobs, because GitHub caps concurrent macOS jobs at five** on Free, Pro and Team (50 on
+  Enterprise Cloud) — a much smaller cap than the 20/40/60 on standard runners. Exceeding it queues
+  rather than fails, and a queued shard lands at roughly twice the shard time, so five is a budget:
+  one `macos-checks` plus four shards. That is also why the Release gate is not a job of its own —
+  it would cost a shard slot and lengthen the run.
+- **Each shard builds for itself** rather than downloading products from a shared
+  `build-for-testing` job. The shards run concurrently, so the ~5-minute Debug build was never on the
+  critical path more than once; building once would move it onto a *serial* job ahead of every shard
+  and add a tar, an upload and four downloads. Build-once saves runner minutes, which this repository
+  is not billed for, and risks a code signature that does not survive the round trip — which presents
+  as a broken suite, not a broken artifact.
+
+## The shard split is checked, not remembered
+
+Sharding by `-only-testing:MimicUITests/<Class>` introduces a failure that the single job could not
+have: **a class no shard names never runs, and every shard is green.** `Scripts/check_ui_shards.py`
+runs in the Linux job and in `Scripts/ci.sh`, and fails on a class in no shard, a class in two, and a
+shard naming a class that no longer exists (which `xcodebuild` reports as "no tests to run", exit 0).
+It reads the workflow as text and `MimicUITests/` as text — no PyYAML, because the Linux container
+installs `python3-minimal`.
+
+Today's split is 40 / 38 / 39 / 41 across the ten classes, balanced longest-first by **test count**,
+which is a proxy for time rather than time itself — a defensible one, since nearly every test launches
+the app and per-test cost is dominated by launch. To rebalance from real data, take a shard's
+`xcresult-ui-N` artifact and read the per-test durations out of it:
+
+```bash
+xcrun xcresulttool get test-results tests --path UITests.xcresult
+```
+
+Then edit the `matrix` in the workflow; nothing else has to move.
+
+**Branch protection is configured by job name**, and `Build and test (macOS)` no longer exists. The
+required checks are `Build, unit suites, Release, CLI e2e (macOS)` and `UI suite` — the latter exists
+partly so that the required name survives any future reshuffle of the shards.
 
 **Linux** builds through [`Package.swift`](../../../../Package.swift) rather than Tuist — the domain rules, mock
 engine, persistence, control plane, spec import and CLI are plain Swift, so most of the suite reports
@@ -33,12 +99,26 @@ them on lights up every portable module at once, and going red before anyone can
 errors helps nobody. The gap is visible on every run instead of silent, and the step goes quiet on
 its own the day `swiftSettings:` lands.
 
-**macOS** (`macos-26`) covers everything that needs Xcode: `tuist generate`, the Debug build, the
-app-level suites, **the XCUITest suite**, the CLI end-to-end check — non-gating, for the reason
-below — and the Release gate. The image label is load-bearing — macOS 26 and Swift
-6.2 are the compile floor, not a preference.
+**macOS** (`macos-26`) covers everything that needs Xcode, across two job definitions that run at the
+same time. `macos-checks` does `tuist generate`, the Debug build, the app-level suites, the CLI
+end-to-end check — non-gating, for the reason below — and the Release gate. `macos-ui` does **the
+XCUITest suite**, in four shards. The image label is load-bearing on both — macOS 26 and Swift 6.2
+are the compile floor, not a preference.
 
-Two things about the macOS job are worth knowing before you edit it:
+Four things about the macOS jobs are worth knowing before you edit them:
+
+- **The setup lives in a composite action.** `.github/actions/macos-setup` holds what all five macOS
+  jobs do before they build: Xcode and Swift versions, `automationmodetool`, Tuist at the pinned
+  `mise.toml` version, its dependency cache, the `Tuist/Package.resolved` drift check, and `tuist
+  generate`. Five pasted copies of those seven steps and their comments is the duplication AGENTS.md
+  names outright. Two constraints when editing it: every `run:` step needs an explicit `shell: bash`,
+  and `continue-on-error:` is a workflow-level key that composite steps do not take — end a
+  diagnostic in `|| true` instead.
+- **`Scripts/print_test_failures.sh` is how a failure gets read.** It prints compile errors out of
+  the build log first (an xcresult cannot carry one — a test target that fails to build produces a
+  bundle with `totalTestCount: 0`), then every failure with its message, file and line out of the
+  newest bundle it was handed. Both test-running job kinds call it on `failure()`, which is why it is
+  a script rather than forty lines of embedded Python pasted five times. It always exits 0.
 
 - **`sudo automationmodetool enable-automationmode-without-authentication` is what makes XCUITest
   possible at all.** Since Monterey, macOS asks a human to approve UI automation before a runner may
@@ -58,11 +138,14 @@ used to be commented out and the macOS job disabled. Making the repo public reso
 in this order: lockfiles, compiler settings, module edges, `swift test`, `tuist install && generate`,
 the Debug build, every unit suite, the Release gate, the UI suite, `check_house_rules.sh --self-test`
 followed by the real house rules scan, `check_doc_counts.py --self-test` followed by the real count
-check, `check_skills.py`, and — last, and gating here from the start — the CLI end-to-end check. The
+check, `check_skills.py`, `check_ui_shards.py --self-test` followed by the real shard check, and —
+last, and gating here from the start — the CLI end-to-end check. The
 three manifest checks near the top run before anything
 compiles, `check_module_edges.py` among them, because a drift there makes every step below it test a
-build that does not ship. Its own header names the three things it cannot reproduce — `swift test`
+build that does not ship. Its own header names the four things it cannot reproduce — `swift test`
 runs on this machine's toolchain rather than in the `swift:6.2` container, the UI suite runs without
-CI's `-retry-tests-on-failure`, and runner setup is absent — so read it rather than treating a green
-local run as a green CI run.
+CI's `-retry-tests-on-failure`, runner setup is absent, and **the UI suite runs in one pass on one
+machine rather than in four shards on four**, which is both why it takes about eighty minutes here
+against CI's twenty-nine and why `check_ui_shards.py` is the only thing that can see a missing shard
+entry from a laptop. Read it rather than treating a green local run as a green CI run.
 

--- a/.agents/skills/mimic-ui-tests/SKILL.md
+++ b/.agents/skills/mimic-ui-tests/SKILL.md
@@ -97,19 +97,21 @@ If the runner reports `Timed out while enabling automation mode` with zero tests
 the SIP-protected `automationmode-writer` service, not your suite — see the `mimic-build-and-test`
 skill's `references/ci.md` for what CI does about it.
 
-That one command runs the whole target. **CI does not** — it shards the suite across four macOS
+That one command runs the whole target. **CI does not** — it shards the suite across three macOS
 runners, because these tests cannot share a machine: they share `mimic-uitests.sqlite`, the
 `com.devxa.Mimic.UITests` defaults domain, and — this being a real macOS app rather than a simulator
 — one window server and one frontmost application. Each shard names the classes it runs with
-`-only-testing:MimicUITests/<Class>`.
+`-only-testing:MimicUITests/<Class>`. Three and not more because `macos-checks` takes one macOS slot
+and run #89 measured the concurrent-macOS-job cap at four rather than the documented five; a fourth
+shard queues for about the length of a shard, which is what that run cost.
 
 So **a new test class is not run by CI until it is added to a shard.** Nothing about that fails
-loudly on its own: the four shards each run exactly what they were asked for and all four go green.
+loudly on its own: each shard runs exactly what it was asked for and they all go green.
 `Scripts/check_ui_shards.py` is what closes it, in the Linux CI job and in `Scripts/ci.sh` — a class
 in no shard, a class in two, or a shard naming a class that has been renamed all fail there. When it
 does, add the class to the lightest shard's `only:` list in the `macos-ui` matrix in
-`.github/workflows/ci.yml` and run the checker again; it prints the four totals so you can see where
-the new suite belongs.
+`.github/workflows/ci.yml` and run the checker again; it prints the per-shard totals so you can see
+where the new suite belongs. Add it to a shard rather than adding a shard.
 
 Two smaller consequences of the split, worth knowing before you write a test that trips over one:
 

--- a/.agents/skills/mimic-ui-tests/SKILL.md
+++ b/.agents/skills/mimic-ui-tests/SKILL.md
@@ -96,3 +96,27 @@ xcodebuild -workspace Mimic.xcworkspace -scheme Mimic test \
 If the runner reports `Timed out while enabling automation mode` with zero tests executed, that is
 the SIP-protected `automationmode-writer` service, not your suite — see the `mimic-build-and-test`
 skill's `references/ci.md` for what CI does about it.
+
+That one command runs the whole target. **CI does not** — it shards the suite across four macOS
+runners, because these tests cannot share a machine: they share `mimic-uitests.sqlite`, the
+`com.devxa.Mimic.UITests` defaults domain, and — this being a real macOS app rather than a simulator
+— one window server and one frontmost application. Each shard names the classes it runs with
+`-only-testing:MimicUITests/<Class>`.
+
+So **a new test class is not run by CI until it is added to a shard.** Nothing about that fails
+loudly on its own: the four shards each run exactly what they were asked for and all four go green.
+`Scripts/check_ui_shards.py` is what closes it, in the Linux CI job and in `Scripts/ci.sh` — a class
+in no shard, a class in two, or a shard naming a class that has been renamed all fail there. When it
+does, add the class to the lightest shard's `only:` list in the `macos-ui` matrix in
+`.github/workflows/ci.yml` and run the checker again; it prints the four totals so you can see where
+the new suite belongs.
+
+Two smaller consequences of the split, worth knowing before you write a test that trips over one:
+
+- **A test may not depend on another suite having run.** It never could — each test wipes the
+  defaults domain in `setUpWithError` and each launch resets the store — but now the other suite may
+  be on a different machine entirely, so a cross-suite assumption fails as "works locally, red on
+  CI".
+- **Ports and the discovery file are already shard-safe** and need nothing from you: the suites use
+  disjoint port ranges and `MIMIC_CONTROL_FILE` is suffixed with the runner's pid. Keep both
+  properties when you add a suite that binds a socket.

--- a/.github/actions/macos-setup/action.yml
+++ b/.github/actions/macos-setup/action.yml
@@ -7,9 +7,9 @@ description: >-
 # Why this is an action rather than seven steps pasted into each job.
 #
 # `.github/workflows/ci.yml` used to have exactly one macOS job, so its setup was written once. The
-# UI suite is now sharded across four runners and the non-UI work runs beside them, which makes five
+# UI suite is now sharded across three runners and the non-UI work runs beside them, which makes four
 # macOS jobs — and every one of them needs the same seven steps, carrying the same ~90 lines of
-# comment explaining *why* each is there. Five copies of a comment is five copies that drift, and
+# comment explaining *why* each is there. Four copies of a comment is four copies that drift, and
 # this repository has already paid for that: `Scripts/check_lockfiles.py` exists partly because the
 # workflow and `Scripts/ci.sh` each held a pasted copy of the same check under a comment claiming
 # they were character-for-character identical, and they were not. AGENTS.md states the rule in one

--- a/.github/actions/macos-setup/action.yml
+++ b/.github/actions/macos-setup/action.yml
@@ -1,0 +1,135 @@
+name: macOS setup
+description: >-
+  Everything a macOS job in this repository needs before it can build: UI automation pre-authorised,
+  Tuist installed at the pinned version, its dependency cache restored, the lockfile held to the
+  commit, and the workspace generated.
+
+# Why this is an action rather than seven steps pasted into each job.
+#
+# `.github/workflows/ci.yml` used to have exactly one macOS job, so its setup was written once. The
+# UI suite is now sharded across four runners and the non-UI work runs beside them, which makes five
+# macOS jobs — and every one of them needs the same seven steps, carrying the same ~90 lines of
+# comment explaining *why* each is there. Five copies of a comment is five copies that drift, and
+# this repository has already paid for that: `Scripts/check_lockfiles.py` exists partly because the
+# workflow and `Scripts/ci.sh` each held a pasted copy of the same check under a comment claiming
+# they were character-for-character identical, and they were not. AGENTS.md states the rule in one
+# line — a rule written twice is a rule that will drift.
+#
+# The cost is that a reader of the workflow no longer sees the setup inline. That is the trade, and
+# it is the one this repository's own history argues for.
+#
+# Two constraints this file is written against, both of which bite silently:
+#
+#   - **Every `run:` step needs `shell: bash`.** It is optional in a workflow and mandatory in a
+#     composite action; omitting it is a hard error at run time, not at parse time.
+#   - **No `continue-on-error:` on a composite step.** It is a workflow-level key, and a composite
+#     action that uses it is a wager on behaviour this repository cannot test from where it is
+#     written. The diagnostic step below ends in `|| true` instead, which needs no keyword and
+#     cannot be spelled wrong.
+#
+# The caller must run `actions/checkout` first — a local action referenced by path only exists once
+# the repository is on disk.
+#
+# Pinned by commit, exactly as the workflow pins: a tag is a moving pointer its owner can repoint,
+# and these run with repository context on pull requests from forks. The trailing comment is the
+# human-readable version; the SHA is what actually runs.
+
+runs:
+  using: composite
+  steps:
+    # macOS 26 and Swift 6.2 are the floor: `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and the
+    # macOS 26 SDK are both required to compile at all, so the image label is load-bearing rather
+    # than a preference. Printed so a green run says which Xcode produced it.
+    - name: Xcode and Swift versions
+      shell: bash
+      run: |
+        xcodebuild -version
+        swift --version
+        sw_vers
+
+    # The one thing that makes macOS XCUITest possible on a hosted runner.
+    #
+    # Since Monterey, macOS asks a human to approve UI automation before a test runner may drive
+    # another app. Nobody is at the keyboard here, so the request is never answered and the runner
+    # fails to initialise at all: `Timed out while enabling automation mode`, zero tests executed —
+    # which reads like a broken suite rather than a missing permission. This is the supported way to
+    # pre-authorise it, and it is why the UI tests can run here at all.
+    #
+    # It runs in *every* macOS job, not only the sharded UI ones, and that is deliberate rather than
+    # sloppy. The non-UI job runs `Scripts/run_cli_e2e.sh`, which launches the real app as a child
+    # process; whether any part of that path is gated on the same authorisation could not be checked
+    # from where this was written, and the step costs about a second. A second on four jobs is
+    # cheaper than one unexplained red run.
+    - name: Allow UI automation without an interactive prompt
+      shell: bash
+      run: sudo automationmodetool enable-automationmode-without-authentication
+
+    # Tuist generates the workspace; nothing in the repo is a checked-in Xcode project.
+    #
+    # Pinned in `mise.toml`, not `brew install tuist`. Homebrew hands out whatever is current — it
+    # produced 4.202.6 against the 4.152.0 this project is developed on, and `tuist install` failed
+    # outright. A generator that silently tracks upstream turns "someone else released" into "our CI
+    # is red".
+    #
+    # The version lives in `mise.toml` rather than here because this action takes no `tools` input —
+    # passing one is accepted, warned about, and ignored, which installs nothing and leaves `tuist`
+    # off PATH for a step that then fails with exit 127.
+    - name: Install Tuist
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
+    # Tuist resolves the SPM dependencies into the workspace, so this cache is what keeps a run from
+    # rebuilding Vapor and GRDB from source every time.
+    #
+    # Now restored by five jobs per run rather than one. They share a key, so the first run on a new
+    # `Tuist/Package.resolved` has five concurrent misses and five concurrent saves of the same
+    # content; `actions/cache` resolves that by refusing the duplicate saves with a warning, which is
+    # noise rather than a failure. Every run after it is five hits.
+    - name: Cache Tuist dependencies
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/.cache/tuist
+          Tuist/.build
+        key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved', 'Project.swift') }}
+        restore-keys: ${{ runner.os }}-tuist-
+
+    # The macOS half of the lockfile invariant. `tuist install` is a SwiftPM resolve behind another
+    # name, so it rewrites `Tuist/Package.resolved` on exactly the same trigger — a range that
+    # resolves differently on this runner than on the machine that committed it. It is checked here
+    # rather than in a step of its own so that it lands before `tuist generate`: the workspace every
+    # step below builds and tests is generated from whatever `install` resolved, and a lockfile that
+    # moved is a workspace that does not match the commit.
+    #
+    # No macOS job has a counterpart to the Linux `Lockfiles agree` step, because that check is
+    # platform-independent and running it twice buys nothing — but it means this line is the only
+    # thing standing between a re-resolved Tuist lockfile and a green run. It is now run by all five
+    # macOS jobs, so the guarantee holds on whichever of them a re-resolve happens to hit.
+    - name: Resolve and generate
+      shell: bash
+      run: |
+        tuist version
+        tuist install
+        git diff --exit-code -- Tuist/Package.resolved || {
+          echo "::error::tuist install re-resolved Tuist/Package.resolved (diff above). The workspace this job generated is not the one the commit describes. Reproduce with 'tuist install', commit the result, and move Package.resolved with it — Scripts/check_lockfiles.py is what says whether they still agree."
+          exit 1
+        }
+        tuist generate --no-open
+
+    # Tuist reports failures as an unhelpful "Error" and writes the reason to a session log the
+    # runner throws away. Without this a failure here says nothing at all.
+    #
+    # `if: failure()` inside a composite action sees the composite's own steps, so this fires when
+    # the resolve or the generate above failed and not when a build fails three steps later in the
+    # calling job. That is narrower than the workflow-level step it replaces, and it is the correct
+    # width: the step only ever had anything to say about Tuist.
+    #
+    # `|| true` on the pipeline instead of `continue-on-error:`, for the reason in the header. This
+    # only ever explains a red run; it must never be the reason for one.
+    - name: Tuist logs on failure
+      if: failure()
+      shell: bash
+      run: |
+        find ~/.local/state/tuist/sessions -name logs.txt 2>/dev/null | while read -r f; do
+          echo "-- $f"
+          tail -100 "$f"
+        done || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ name: CI
 # seconds with zero steps executed, which is why the automatic triggers used to be commented out and
 # the macOS job was `if: false`. Making the repo public resolved it.
 #
-# ## Why there are five macOS jobs and not one
+# ## Why there are four macOS jobs and not one
 #
 # There used to be one, and it ran strictly in sequence: setup, Debug build, unit suites, coverage,
 # **XCUITest**, CLI end-to-end, Release. Run #87 (green, 6aeff91) measured it at about **96 minutes**
@@ -26,8 +26,8 @@ name: CI
 #
 #   1. **The non-UI macOS work moved into its own job** (`macos-checks`), so the Debug build, the
 #      unit suites with their coverage measurement, the CLI end-to-end check and the Release gate all
-#      report in around sixteen minutes instead of ninety-six.
-#   2. **The UI suite is sharded across four runners** (`macos-ui`), each running a named subset of
+#      report in around twenty minutes instead of ninety-six — 19m43 measured on run #89.
+#   2. **The UI suite is sharded across three runners** (`macos-ui`), each running a named subset of
 #      the test classes with `-only-testing:`.
 #
 # ## Why sharding, and never `-parallel-testing-enabled`
@@ -51,31 +51,49 @@ name: CI
 # 62311–62314) and already suffix `MIMIC_CONTROL_FILE` with the runner's pid, so two shards running
 # at the same moment cannot collide on a socket or on a discovery file either.
 #
-# ## Why exactly five macOS jobs
+# ## Why exactly four macOS jobs — the cap is four here, whatever the documentation says
 #
-# **GitHub caps concurrent macOS jobs at five** on Free, Pro and Team plans — a separate, much
-# smaller cap than the 20/40/60 on standard runners, and one that is shared across standard and
-# larger runners. (Enterprise Cloud gets 50. This is a public repository on the free tier, so five is
-# the number this file is designed against.) Free minutes do not enter into it: what is scarce here
-# is slots, not money.
+# **Read this before adding a macOS job.** GitHub documents the concurrent-macOS-job limit as **five**
+# on Free, Pro and Team plans — a separate, much smaller cap than the 20/40/60 on standard runners,
+# shared across standard and larger runners, with Enterprise Cloud at 50. This file was first written
+# against that documented five: one `macos-checks` plus four shards.
+#
+# **What run #89 actually did was four.** That run (green, 62b80e7) requested five macOS jobs at once.
+# Four of them — `macos-checks` and shards 1, 2 and 3 — started together at 22:01:49. Shard 4 did not
+# start until 22:21:15, **19m26 after the other four**, and two seconds after shard 2 finished and
+# freed a slot. That is not a slow start, it is a queue: the fifth job waited for the first completion
+# and then began, which cost the run the length of a whole shard. Real wall clock was **~43 minutes**
+# against the ~29 this header and the pull request both predicted.
+#
+# The honest form of the claim is therefore an observation and not a rule: **the documented figure is
+# five, the observed concurrency on this repository was four, and a fifth macOS job queued for
+# roughly the length of a shard.** The documentation may well be right in general and wrong for this
+# account, this plan or this runner pool; what is not in doubt is what happened on run #89. Anyone who
+# wants a fifth macOS job — another shard, or the Release gate split out of `macos-checks` — should
+# expect it to queue, and should say so with a measurement rather than with the documented number.
+# One run is enough evidence to design against and not enough to call the documentation wrong.
 #
 # Going over the cap does not fail, it queues — and a queued shard is the worst outcome available,
-# because it starts only when another finishes and so lands at roughly *twice* the shard time. Five
-# jobs is therefore a budget, not an estimate:
+# because it starts only when another finishes and so lands at roughly *twice* the shard time. Four
+# jobs is therefore a budget, measured rather than estimated:
 #
 #     macos-checks   1 slot    Debug build, unit suites, coverage, CLI e2e, Release
-#     macos-ui       4 slots   the XCUITest suite, in four shards
+#     macos-ui       3 slots   the XCUITest suite, in three shards
 #     ────────────────────────
-#                    5 slots
+#                    4 slots
+#
+# Fewer, larger shards is the right trade under an observed cap of four. Three shards of ~53 tests
+# each are longer than four of ~40, but nothing queues, and a shard that runs is worth more than a
+# shard that waits: the four-shard split spent 19m26 of wall clock on a slot that did not exist.
 #
 # That is also why the non-UI work is *one* job rather than three. Splitting the Release gate and the
 # end-to-end check into jobs of their own would buy about eight minutes on a path the UI shards
-# already dominate, and it would cost two shard slots — pushing the shards from four to two and the
-# whole run from roughly twenty-nine minutes to over fifty. The arithmetic runs the other way from
-# the intuition, and the cap is why.
+# already dominate, and it would cost two shard slots — pushing the shards from three to one and the
+# whole run past eighty minutes. The arithmetic runs the other way from the intuition, and the cap is
+# why.
 #
 # One consequence worth knowing: `cancel-in-progress` is deliberately off for pushes to `main` (see
-# `concurrency` below), so two overlapping pushes there put ten macOS jobs against a cap of five and
+# `concurrency` below), so two overlapping pushes there put eight macOS jobs against a cap of four and
 # the second run's shards queue behind the first's. That is accepted. It is the same trade the
 # concurrency comment already makes — on `main`, a completed run per commit is worth more than a fast
 # one — and pull requests, where the feedback loop actually matters, still cancel.
@@ -89,36 +107,57 @@ name: CI
 #
 # Building once removes the ~5-minute Debug build from each shard's clock — but the shards run *at
 # the same time*, so that build was never on the critical path more than once to begin with. What
-# building once actually does is take that build off five parallel clocks and put it on one serial
-# one, ahead of every shard, and then add a tar, an upload and four downloads of a macOS `.app` on
-# top. Measured against the estimates below it is a wash at best and slower at worst. Build-once
+# building once actually does is take that build off four parallel clocks and put it on one serial
+# one, ahead of every shard, and then add a tar, an upload and three downloads of a macOS `.app` on
+# top. Measured against the timings below it is a wash at best and slower at worst. Build-once
 # saves *runner minutes*, which are the thing this repository is not billed for.
 #
 # And it is the riskier of the two. A macOS `.app` moved through `actions/upload-artifact` loses
 # symlinks and permissions unless it is tarred first, an `.xctestrun` carries paths that must land
 # where it expects them, and a code signature that does not survive the round trip means every shard
-# fails to launch the app — which presents as a broken suite, not as a broken artifact. Paying five
+# fails to launch the app — which presents as a broken suite, not as a broken artifact. Paying four
 # concurrent builds to avoid all of that is the trade this file takes. A slower CI that works beats a
 # faster one that is flaky.
 #
-# The five builds are not from cold: `Tuist/.build` and `~/.cache/tuist` are restored from the same
-# cache key in all five jobs, so what each shard compiles is this repository's own sources against
+# The four builds are not from cold: `Tuist/.build` and `~/.cache/tuist` are restored from the same
+# cache key in all four jobs, so what each shard compiles is this repository's own sources against
 # already-resolved dependencies. Caching **DerivedData** itself would cut the shard build further and
 # is also deliberately not done — a restored Xcode module cache that disagrees with the toolchain
 # fails as "module compiled with Swift X cannot be imported by Swift Y", which reads as a source
 # problem and reproduces nowhere locally. The Linux job's cache key carries the compiler version for
-# exactly that reason; until someone is prepared to key DerivedData as carefully, five honest builds
+# exactly that reason; until someone is prepared to key DerivedData as carefully, four honest builds
 # is the cheaper mistake.
 #
-# ## Expected shape of a run
+# ## Shape of a run, measured
 #
-#     linux         ~2m30   unchanged
-#     macos-checks   ~16m   1m35 setup + 5m09 Debug + 3m18 unit + coverage + e2e + Release
-#     macos-ui       ~29m   1m35 setup + 5m09 Debug + ~1m30 test-target compile + ~20m of tests
-#     ui-suite         ~0m   Linux; rolls the four shard results into one status check
+# Run #89 (62b80e7), the first real run of the sharded workflow, with four shards against a cap that
+# turned out to be four:
 #
-# About **96 minutes to about 29**. The first red is faster still: a compile break or a unit failure
-# lands in `macos-checks` inside ten minutes.
+#     linux                    2m20   measured
+#     macos-checks            19m43   measured
+#     macos-ui shard 2 (38)   19m23   measured
+#     macos-ui shard 1 (40)   21m18   measured
+#     macos-ui shard 3 (39)   23m49   measured
+#     macos-ui shard 4 (41)   19m26 queued, then ~22m   ← the job there was no slot for
+#     ────────────────────────────────
+#     wall clock              ~43m
+#
+# Those shard times give the constant everything below is derived from: shard 3 ran 39 tests in a
+# 22m42 step that also contains the Debug build and the test-target compile, so a UI test costs
+# **about 26 seconds**.
+#
+# With three shards and nothing queueing:
+#
+#     linux                   ~2m20   unchanged
+#     macos-checks           ~19m43   unchanged; comfortably inside the shards
+#     macos-ui  (51/53/54)    ~30m    ~1m setup + ~5m Debug + ~1m30 test-target compile
+#                                     + 54 × 26s ≈ 23m24 of tests on the heaviest shard
+#     ui-suite                 ~0m    Linux; rolls the three shard results into one status check
+#
+# So: **96 minutes originally, 43 measured with four shards, about 30 expected with three.** The
+# saving is not from running less — it is the same 158 tests either way — it is from stopping asking
+# for a fifth concurrent macOS job that does not exist. The first red is faster still: a compile
+# break or a unit failure lands in `macos-checks` inside ten minutes.
 on:
   push:
     branches: [main]
@@ -275,9 +314,9 @@ jobs:
 
       # The gate the sharded UI job needs and could not have needed before it existed.
       #
-      # `macos-ui` below runs the XCUITest suite as four shards, and it splits them by naming test
+      # `macos-ui` below runs the XCUITest suite as three shards, and it splits them by naming test
       # classes: each shard passes a list of `-only-testing:MimicUITests/<Class>` flags. A class that
-      # no shard names therefore never runs — and all four shards go green, because each ran exactly
+      # no shard names therefore never runs — and every shard goes green, because each ran exactly
       # what it was asked for. Add a suite tomorrow, write twenty tests in it, and CI reports the
       # window covered.
       #
@@ -377,9 +416,9 @@ jobs:
   macos-checks:
     name: Build, unit suites, Release, CLI e2e (macOS)
     runs-on: macos-26
-    # It was 120 when this job also carried the ~80-minute UI suite. What is left measures around
-    # sixteen minutes, so this is generous by nearly threefold and still tight enough that a wedged
-    # runner is cut loose within the hour.
+    # It was 120 when this job also carried the ~80-minute UI suite. What is left measured 19m43 on
+    # run #89, so this is generous by more than twofold and still tight enough that a wedged runner
+    # is cut loose within the hour.
     timeout-minutes: 45
 
     # The measured coverage figures, handed to `record-coverage` below. Empty on every run that is
@@ -411,8 +450,8 @@ jobs:
 
       # Xcode and Swift versions, UI automation pre-authorised, Tuist at the pinned version, its
       # cache restored, `Tuist/Package.resolved` held to the commit, and `tuist generate`. One copy,
-      # shared by this job and the four shards below — see the action's own header for why it is a
-      # file rather than seven steps pasted five times.
+      # shared by this job and the three shards below — see the action's own header for why it is a
+      # file rather than seven steps pasted four times.
       - uses: ./.github/actions/macos-setup
 
       # Ad-hoc signing throughout. The project carries a DEVELOPMENT_TEAM for local builds, but a
@@ -615,9 +654,10 @@ jobs:
       # what the step below now publishes on every run. Same order the coverage steps above follow:
       # measure first, gate second.
       #
-      # It stays in this job rather than becoming a sixth, for the reason argued in the header: the
-      # cap is five concurrent macOS jobs, a job of its own would have to come out of the shards, and
-      # trading a shard for eight minutes lengthens the run rather than shortening it.
+      # It stays in this job rather than becoming a fifth, for the reason argued in the header: run
+      # #89 measured the concurrent-macOS-job cap at four, not the documented five, so a job of its
+      # own would have to come out of the shards — and trading a shard for eight minutes lengthens
+      # the run rather than shortening it. A fifth job would simply queue, as shard 4 did for 19m26.
       - name: Build (Release)
         run: |
           set -o pipefail
@@ -663,8 +703,8 @@ jobs:
       # The failing assertion, in the job log, where a person can read it — compile errors out of the
       # log first, because an xcresult cannot carry one, then every failure with its message, file
       # and line out of whichever bundle is newest. The logic moved into
-      # `Scripts/print_test_failures.sh` when the UI suite was sharded: five test-running jobs would
-      # otherwise hold five pasted copies of the same forty-line walker, and a copy that has quietly
+      # `Scripts/print_test_failures.sh` when the UI suite was sharded: four test-running jobs would
+      # otherwise hold four pasted copies of the same forty-line walker, and a copy that has quietly
       # stopped printing failures looks exactly like a run that had none.
       #
       # Both bundle locations are named. This used to look only under `$DERIVED_DATA`, which is where
@@ -698,7 +738,7 @@ jobs:
       # survives in full.
       #
       # Named `xcresult-unit` rather than `xcresult`, because artifact names must be unique within a
-      # run and the four UI shards below each upload one of their own. Still `if: failure()` — a
+      # run and the three UI shards below each upload one of their own. Still `if: failure()` — a
       # coverage-instrumented bundle is large, and uploading one on every green run buys a reviewer
       # nothing the summary has not already shown them.
       - name: Upload test results
@@ -716,9 +756,10 @@ jobs:
   # XCUITest is the only thing that exercises the real window — the accessibility tree, the panel
   # layout, and every flow a user actually takes.
   #
-  # Four shards, four runners, four disjoint sets of test classes. The header of this file argues why
-  # sharding across machines rather than `-parallel-testing-enabled` on one, and why four rather than
-  # some other number; what follows is how the four were chosen.
+  # Three shards, three runners, three disjoint sets of test classes. The header of this file argues
+  # why sharding across machines rather than `-parallel-testing-enabled` on one, and why three rather
+  # than some other number — the observed cap of four concurrent macOS jobs, minus the one
+  # `macos-checks` takes. What follows is how the three were chosen.
   #
   # ## How the shards are balanced
   #
@@ -734,10 +775,12 @@ jobs:
   #                                        JourneyUITests              7
   #                                        ControlPlaneIsolationTests  1
   #
-  # 158 in total, so a perfect quarter is 39.5. Longest-processing-time-first — take the classes
-  # largest to smallest and put each on the shard that is currently lightest — gives 40 / 38 / 39 /
-  # 41, which is within four percent of even and cannot be beaten by much given a 33-test class that
-  # cannot be split.
+  # 158 in total, so a perfect third is 52.7. The split below is **51 / 53 / 54**, within 2.5% of even
+  # and short of optimal by one test: exhaustively searching every way of dealing ten classes onto
+  # three shards, the smallest achievable spread is 2 (52 / 52 / 54) and this one takes 3. What the
+  # extra test buys is a shard whose name a reader can trust — the spread-2 splits pair the workspace
+  # shell with the endpoint editor, and a shard called "workspace shell and endpoint editor" tells
+  # nobody where to look when it goes red. One test is about 26 seconds; the naming is worth more.
   #
   # **Whole classes, never individual tests.** `-only-testing:` accepts a method, and using it would
   # let the shards be balanced to the test — but the split would then have to be rewritten every time
@@ -745,14 +788,20 @@ jobs:
   # run" rather than with anything a reader would connect to the rename. A class is a unit that moves
   # as a whole.
   #
-  # **The proxy is worth re-checking against real times once a few runs exist**, and the data is
-  # already in each shard's own result bundle. Download a shard's `xcresult-ui-N` artifact and ask
+  # **Test count is still the estimator, and run #89 supports it rather than replacing it.** Its four
+  # shards ran 40 / 38 / 39 / 41 tests in 21m18 / 19m23 / 23m49 / ~22m — the ordering does not track
+  # the counts exactly (shard 3 ran fewer tests than shard 1 and took longer), so per-class cost is
+  # not perfectly uniform, but the spread of times is small enough that counting tests remains the
+  # honest cheap approximation. The constant that falls out is **~26 seconds per test**, from shard
+  # 3's 39 tests in a 22m42 step that also carries the build and the test-target compile.
+  #
+  # To do better than counting, the per-test data is already in each shard's own result bundle.
+  # Download a shard's `xcresult-ui-N` artifact and ask
   #
   #     xcrun xcresulttool get test-results tests --path UITests.xcresult
   #
   # for the per-test durations, sum them by class, and rebalance by editing the `matrix` below —
-  # which is a one-line change per shard and needs nothing else in this file touched. Until somebody
-  # does, test count is the honest estimator and this comment is the record that it is an estimator.
+  # which is a one-line change per shard and needs nothing else in this file touched.
   #
   # ## What each shard needs that a single job did not
   #
@@ -770,52 +819,49 @@ jobs:
   macos-ui:
     name: UI tests (${{ matrix.name }})
     runs-on: macos-26
-    # A shard measures around 29 minutes: 1m35 setup, ~5m09 for the Debug build, ~1m30 to compile the
-    # test target, and ~20m of tests. Double it and round, so a shard that hits `-test-iterations 2`
-    # on several tests still finishes rather than being cut off mid-retry.
+    # A ~40-test shard of the old four-way split measured 19m23 to 23m49 on run #89. The heaviest here
+    # carries 54, so about 30 minutes: ~1m setup, ~5m for the Debug build, ~1m30 to compile the test
+    # target, and 54 × 26s ≈ 23m24 of tests. Double it and round, so a shard that hits
+    # `-test-iterations 2` on several tests still finishes rather than being cut off mid-retry.
     timeout-minutes: 60
 
     strategy:
-      # Never `fail-fast`. The default would cancel the other three shards the moment one goes red,
-      # which turns "four independent verdicts" back into "one verdict, chosen by whichever shard
+      # Never `fail-fast`. The default would cancel the other two shards the moment one goes red,
+      # which turns "three independent verdicts" back into "one verdict, chosen by whichever shard
       # failed first" — and the failure this suite is documented as producing most often is a
-      # SIGKILLed launch under memory pressure, which says nothing about the other three. A red run
+      # SIGKILLed launch under memory pressure, which says nothing about the other two. A red run
       # should say which parts of the window are broken, all of them, in one pass.
       fail-fast: false
       matrix:
         include:
-          # 40 tests. `MimicUITests` is the original suite and the largest single class in the
-          # target; it goes on a shard of its own with only the seven-test journeys suite beside it.
+          # 51 tests, and the lightest shard, which is why the one-test isolation class rides here:
+          # `ControlPlaneIsolationTests` launches the app like everything else, so it costs a launch
+          # wherever it lands, and the lightest shard is where a rounding error should go. It is the
+          # one class this shard's name does not mention — one test does not earn a fourth clause.
           - id: 1
-            name: core window and journeys
+            name: core window, journeys, spec import
             only: >-
               -only-testing:MimicUITests/MimicUITests
               -only-testing:MimicUITests/JourneyUITests
-
-          # 38 tests, and the lightest shard, which is why the one-test isolation class rides here:
-          # `ControlPlaneIsolationTests` launches the app like everything else, so it costs a launch
-          # wherever it lands, and the lightest shard is where a rounding error should go.
-          - id: 2
-            name: workspace shell, spec import, isolation
-            only: >-
-              -only-testing:MimicUITests/WorkspaceShellUITests
               -only-testing:MimicUITests/SpecImportUITests
               -only-testing:MimicUITests/ControlPlaneIsolationTests
 
-          # 39 tests.
+          # 53 tests.
+          - id: 2
+            name: workspace shell, welcome, request log
+            only: >-
+              -only-testing:MimicUITests/WorkspaceShellUITests
+              -only-testing:MimicUITests/WelcomeProjectUITests
+              -only-testing:MimicUITests/RequestLogUITests
+
+          # 54 tests, the heaviest, and so the one to watch first if the estimate is wrong — it is
+          # also the shard the 30-minute figure in this job's `timeout-minutes` comment is about.
           - id: 3
-            name: endpoint editor and error alerts
+            name: endpoint editor, alerts, journey editor
             only: >-
               -only-testing:MimicUITests/EndpointEditorUITests
               -only-testing:MimicUITests/ErrorAlertUITests
-
-          # 41 tests, the heaviest, and so the one to watch first if the estimate is wrong.
-          - id: 4
-            name: welcome, journey editor, request log
-            only: >-
-              -only-testing:MimicUITests/WelcomeProjectUITests
               -only-testing:MimicUITests/JourneyEditorUITests
-              -only-testing:MimicUITests/RequestLogUITests
 
     # Same reasoning as the job above: DerivedData inside the checkout, `.artifacts/` is gitignored,
     # and the steps that read it read it from here.
@@ -829,8 +875,8 @@ jobs:
 
       # No separate `Build (Debug)` step: `xcodebuild test` builds what the test action needs, and a
       # shard needs nothing else. The build is not free — it is about five minutes of this shard's
-      # twenty-nine — but it runs on four machines at once, so it costs the *run* five minutes rather
-      # than twenty. That is the whole build-once-versus-build-per-shard argument, and it is made in
+      # thirty — but it runs on three machines at once, so it costs the *run* five minutes rather
+      # than fifteen. That is the whole build-once-versus-build-per-shard argument, and it is made in
       # full in this file's header.
       #
       # `-retry-tests-on-failure` is not papering over flakiness in the app: this suite launches the
@@ -853,7 +899,7 @@ jobs:
       # be data. This value is written three inches above in the same file; the habit is the point.
       #
       # `-resultBundlePath` for the same reason the unit step names one, and with the shard id in the
-      # path so the four uploads below cannot collide. `tee` for the reason that step documents: a
+      # path so the three uploads below cannot collide. `tee` for the reason that step documents: a
       # compile failure in the test target produces a bundle with `totalTestCount: 0`, so the errors
       # exist only in this output.
       - name: Test (UI)
@@ -894,9 +940,9 @@ jobs:
             "$DERIVED_DATA"/Logs/Test/*.xcresult
 
       # One artifact per shard, named by shard id — `upload-artifact` refuses a duplicate name within
-      # a run, and four shards uploading `xcresult` would be four collisions. The name is also how a
-      # reader gets from "shard 3 is red" to the screenshots for shard 3 without downloading the
-      # other three.
+      # a run, and three shards uploading `xcresult` would be three collisions. The name is also how
+      # a reader gets from "shard 3 is red" to the screenshots for shard 3 without downloading the
+      # other two.
       #
       # `if: failure()`, as before: these bundles are large and a green run's is worth nothing.
       - name: Upload test results
@@ -910,14 +956,15 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # One status check standing for all four shards.
+  # One status check standing for all three shards.
   #
   # Each shard already fails the run on its own, so this job changes no verdict. What it buys is a
   # **stable name**: branch protection requires checks by name, and `UI tests (core window and
   # journeys)` is a name that changes the day somebody rebalances the matrix — at which point the
   # required check silently refers to a job that no longer runs, and `main` starts accepting commits
   # whose UI suite nobody looked at. Requiring `UI suite` instead survives any reshuffle of the
-  # shards, including changing how many there are.
+  # shards, including changing how many there are — which is exactly what the rebalance from four
+  # shards to three did, and this job's name did not move.
   #
   # It runs on Linux and does nothing but read a result, so it costs no macOS slot and no measurable
   # time.
@@ -925,7 +972,7 @@ jobs:
   # It reports *that* something is red, not *which* — deliberately. Telling a reader which shard
   # failed would mean each shard publishing a marker and this job collecting them with
   # `download-artifact`, which this workflow has never pinned and a SHA is not a thing to guess at.
-  # The run page already answers it: the four shards are named for the parts of the window they
+  # The run page already answers it: the three shards are named for the parts of the window they
   # cover, and the red one is the red one.
   #
   # `!cancelled()` rather than `always()`. With `always()` this job would run after a pull request
@@ -940,16 +987,16 @@ jobs:
 
     steps:
       # `needs.<job>.result` over a matrix job is the roll-up of every leg: `success` only when all
-      # four passed, `failure` when any failed, `skipped` when the matrix never ran.
+      # three passed, `failure` when any failed, `skipped` when the matrix never ran.
       - name: Verdict
         env:
           RESULT: ${{ needs.macos-ui.result }}
         run: |
           set -euo pipefail
-          echo "The four UI shards rolled up to: $RESULT"
+          echo "The three UI shards rolled up to: $RESULT"
           case "$RESULT" in
             success)
-              echo "All four shards passed — 158 XCUITest cases across the four runners."
+              echo "All three shards passed — 158 XCUITest cases across the three runners."
               ;;
             skipped)
               echo "::error::The UI shards did not run, so nothing exercised the window on this commit."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
-# Two runners, split by what actually needs a Mac.
+# Split by what actually needs a Mac, and then — on the Mac — by what can be run at the same time as
+# what.
 #
 # The domain rules, the mock engine, persistence, the control plane, spec import and the CLI are
 # plain Swift — Vapor's native home is Linux — so `Package.swift` builds them on a Linux runner and
@@ -11,6 +12,113 @@ name: CI
 # included. That was not always true here — while this repo was private, every run died in about two
 # seconds with zero steps executed, which is why the automatic triggers used to be commented out and
 # the macOS job was `if: false`. Making the repo public resolved it.
+#
+# ## Why there are five macOS jobs and not one
+#
+# There used to be one, and it ran strictly in sequence: setup, Debug build, unit suites, coverage,
+# **XCUITest**, CLI end-to-end, Release. Run #87 (green, 6aeff91) measured it at about **96 minutes**
+# end to end, of which the UI suite alone was about **80**. So four fifths of every pull request's
+# feedback was one step, and the Release gate and the end-to-end check — neither of which the UI
+# suite has anything to do with — sat behind it waiting their turn. A reviewer learned that Release
+# still compiles about ninety minutes after learning that the unit suites pass.
+#
+# Two changes, and they are independent:
+#
+#   1. **The non-UI macOS work moved into its own job** (`macos-checks`), so the Debug build, the
+#      unit suites with their coverage measurement, the CLI end-to-end check and the Release gate all
+#      report in around sixteen minutes instead of ninety-six.
+#   2. **The UI suite is sharded across four runners** (`macos-ui`), each running a named subset of
+#      the test classes with `-only-testing:`.
+#
+# ## Why sharding, and never `-parallel-testing-enabled`
+#
+# The obvious cheaper move is to let one runner run the suite in parallel workers. It is not
+# available here, for two reasons that hold independently — fix either one and the other still
+# stands.
+#
+#   - **The suites share one store and one defaults domain.** `UITestSupport.databaseURL` resolves to
+#     the fixed name `mimic-uitests.sqlite`, `MIMIC_DEFAULTS_SUITE` is the fixed
+#     `com.devxa.Mimic.UITests`, `resetApp` deletes that store on every app launch, and
+#     `setUpWithError` wipes that domain before every test. Two workers on one machine therefore
+#     destroy each other's state mid-test — not flakily, by construction.
+#   - **This is a macOS app, not a simulator.** Parallel workers share one window server and one
+#     frontmost application, and these suites lean on `typeText`, `typeKey` and ⌘-click, all of which
+#     go to whichever app has focus. There is no simulator-clone equivalent to isolate them with.
+#
+# Sharding across runners dissolves both: each shard is its own machine, with its own store, its own
+# defaults domain and its own window server. Nothing in the tests changed to make this work, and
+# nothing needed to — the suites already use disjoint port ranges (21311–21613, 62084–62118,
+# 62311–62314) and already suffix `MIMIC_CONTROL_FILE` with the runner's pid, so two shards running
+# at the same moment cannot collide on a socket or on a discovery file either.
+#
+# ## Why exactly five macOS jobs
+#
+# **GitHub caps concurrent macOS jobs at five** on Free, Pro and Team plans — a separate, much
+# smaller cap than the 20/40/60 on standard runners, and one that is shared across standard and
+# larger runners. (Enterprise Cloud gets 50. This is a public repository on the free tier, so five is
+# the number this file is designed against.) Free minutes do not enter into it: what is scarce here
+# is slots, not money.
+#
+# Going over the cap does not fail, it queues — and a queued shard is the worst outcome available,
+# because it starts only when another finishes and so lands at roughly *twice* the shard time. Five
+# jobs is therefore a budget, not an estimate:
+#
+#     macos-checks   1 slot    Debug build, unit suites, coverage, CLI e2e, Release
+#     macos-ui       4 slots   the XCUITest suite, in four shards
+#     ────────────────────────
+#                    5 slots
+#
+# That is also why the non-UI work is *one* job rather than three. Splitting the Release gate and the
+# end-to-end check into jobs of their own would buy about eight minutes on a path the UI shards
+# already dominate, and it would cost two shard slots — pushing the shards from four to two and the
+# whole run from roughly twenty-nine minutes to over fifty. The arithmetic runs the other way from
+# the intuition, and the cap is why.
+#
+# One consequence worth knowing: `cancel-in-progress` is deliberately off for pushes to `main` (see
+# `concurrency` below), so two overlapping pushes there put ten macOS jobs against a cap of five and
+# the second run's shards queue behind the first's. That is accepted. It is the same trade the
+# concurrency comment already makes — on `main`, a completed run per commit is worth more than a fast
+# one — and pull requests, where the feedback loop actually matters, still cancel.
+#
+# ## Why each shard builds for itself instead of downloading one build
+#
+# The textbook shape for this is `xcodebuild build-for-testing` in one job, then
+# `test-without-building -xctestrun …` in each shard, with the products passed between them as an
+# artifact. It was considered and deliberately not taken, for a reason that is arithmetic before it
+# is risk.
+#
+# Building once removes the ~5-minute Debug build from each shard's clock — but the shards run *at
+# the same time*, so that build was never on the critical path more than once to begin with. What
+# building once actually does is take that build off five parallel clocks and put it on one serial
+# one, ahead of every shard, and then add a tar, an upload and four downloads of a macOS `.app` on
+# top. Measured against the estimates below it is a wash at best and slower at worst. Build-once
+# saves *runner minutes*, which are the thing this repository is not billed for.
+#
+# And it is the riskier of the two. A macOS `.app` moved through `actions/upload-artifact` loses
+# symlinks and permissions unless it is tarred first, an `.xctestrun` carries paths that must land
+# where it expects them, and a code signature that does not survive the round trip means every shard
+# fails to launch the app — which presents as a broken suite, not as a broken artifact. Paying five
+# concurrent builds to avoid all of that is the trade this file takes. A slower CI that works beats a
+# faster one that is flaky.
+#
+# The five builds are not from cold: `Tuist/.build` and `~/.cache/tuist` are restored from the same
+# cache key in all five jobs, so what each shard compiles is this repository's own sources against
+# already-resolved dependencies. Caching **DerivedData** itself would cut the shard build further and
+# is also deliberately not done — a restored Xcode module cache that disagrees with the toolchain
+# fails as "module compiled with Swift X cannot be imported by Swift Y", which reads as a source
+# problem and reproduces nowhere locally. The Linux job's cache key carries the compiler version for
+# exactly that reason; until someone is prepared to key DerivedData as carefully, five honest builds
+# is the cheaper mistake.
+#
+# ## Expected shape of a run
+#
+#     linux         ~2m30   unchanged
+#     macos-checks   ~16m   1m35 setup + 5m09 Debug + 3m18 unit + coverage + e2e + Release
+#     macos-ui       ~29m   1m35 setup + 5m09 Debug + ~1m30 test-target compile + ~20m of tests
+#     ui-suite         ~0m   Linux; rolls the four shard results into one status check
+#
+# About **96 minutes to about 29**. The first red is faster still: a compile break or a unit failure
+# lands in `macos-checks` inside ten minutes.
 on:
   push:
     branches: [main]
@@ -25,6 +133,9 @@ permissions:
 # Every third-party action is pinned to a commit, not a tag. A tag is a moving pointer its owner can
 # repoint at any time, and these run with repository context on pull requests — including forks. The
 # trailing comment is the human-readable version; the SHA is what actually runs.
+#
+# `./.github/actions/macos-setup` is not third-party and takes no SHA: a local action referenced by
+# path is read out of the same commit that is being tested, which is the strongest pin there is.
 
 concurrency:
   # A newer push makes an in-flight run irrelevant *on a pull request*, where only the tip matters.
@@ -162,6 +273,32 @@ jobs:
           python3 Scripts/check_doc_counts.py --self-test
           python3 Scripts/check_doc_counts.py
 
+      # The gate the sharded UI job needs and could not have needed before it existed.
+      #
+      # `macos-ui` below runs the XCUITest suite as four shards, and it splits them by naming test
+      # classes: each shard passes a list of `-only-testing:MimicUITests/<Class>` flags. A class that
+      # no shard names therefore never runs — and all four shards go green, because each ran exactly
+      # what it was asked for. Add a suite tomorrow, write twenty tests in it, and CI reports the
+      # window covered.
+      #
+      # That is the same shape as the `buildableFolders` line naming a `Tests/JourneyFeatureTests`
+      # that did not exist, which Tuist tolerated in silence, and the same shape the suite-folder
+      # check in `Documented counts` above exists to close: on a green pipeline, a suite nobody runs
+      # is indistinguishable from one that passed. It is checked rather than remembered.
+      #
+      # Three verdicts — a class in no shard, a class in two, and a shard naming a class that is not
+      # there (which `xcodebuild` reports as "no tests to run" and exits 0 for). `--self-test` first,
+      # as the two checks around it do: its fixtures are a workflow and a suite tree invented inside
+      # the script, so a parser that has stopped recognising either would fail here rather than
+      # reporting that every class is covered.
+      #
+      # On Linux with the other cheap gates: it reads the workflow as text and `MimicUITests/` as
+      # text, imports nothing outside the standard library, and takes about a tenth of a second.
+      - name: UI shards cover every UI test class
+        run: |
+          python3 Scripts/check_ui_shards.py --self-test
+          python3 Scripts/check_ui_shards.py
+
       # AGENTS.md is a router now: it keeps what is true on every task and sends the rest to a skill
       # under `.agents/skills/`, which is why it is 241 lines rather than the 807 it reached. That
       # bought three promises, and all three fail silently. `.claude/skills/` mirrors the skills by
@@ -227,12 +364,23 @@ jobs:
       - name: Test
         run: swift test --skip-build
 
-  macos:
-    name: Build and test (macOS)
+  # Everything that needs Xcode and does *not* need the window: the Debug build, the app-level unit
+  # suites with the coverage measurement, the CLI end-to-end check, and the Release gate.
+  #
+  # This is the old `macos` job with the UI step lifted out of the middle of it. The rename is not
+  # cosmetic — it is what stops "the macOS job" meaning two unrelated things — but it does have one
+  # consequence outside this file: **required status checks in branch protection are configured by
+  # job name.** `Build and test (macOS)` no longer exists as a check. Whoever merges this must update
+  # the branch rules to require `Build, unit suites, Release, CLI e2e (macOS)` and `UI suite`, or
+  # `main` accepts a commit no macOS job ever looked at. The `UI suite` job at the bottom exists
+  # partly so that the second of those names never has to change again when the shard count does.
+  macos-checks:
+    name: Build, unit suites, Release, CLI e2e (macOS)
     runs-on: macos-26
-    # The Release build alone is several minutes on a 3-core runner, and the UI suite launches the
-    # real app once per test.
-    timeout-minutes: 120
+    # It was 120 when this job also carried the ~80-minute UI suite. What is left measures around
+    # sixteen minutes, so this is generous by nearly threefold and still tight enough that a wedged
+    # runner is cut loose within the hour.
+    timeout-minutes: 45
 
     # The measured coverage figures, handed to `record-coverage` below. Empty on every run that is
     # not a push to `main`, and on any run that failed before the measurement — that job treats an
@@ -250,8 +398,8 @@ jobs:
     #
     # Every step, because the builds are shared: point one of them here and the rest re-resolve and
     # rebuild the whole workspace into the default location instead of reusing this one. The two
-    # places that *read* DerivedData — the UI failure dump and the artifact upload — read it from
-    # here for the same reason.
+    # places that *read* DerivedData — the failure dump and the artifact upload — read it from here
+    # for the same reason.
     #
     # `.artifacts/` is in `.gitignore`, and so is any directory named `DerivedData`, so nothing here
     # can dirty the checkout.
@@ -261,80 +409,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # macOS 26 and Swift 6.2 are the floor: `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and the
-      # macOS 26 SDK are both required to compile at all, so the image label is load-bearing rather
-      # than a preference. Printed so a green run says which Xcode produced it.
-      - name: Xcode and Swift versions
-        run: |
-          xcodebuild -version
-          swift --version
-          sw_vers
-
-      # The one thing that makes macOS XCUITest possible on a hosted runner.
-      #
-      # Since Monterey, macOS asks a human to approve UI automation before a test runner may drive
-      # another app. Nobody is at the keyboard here, so the request is never answered and the runner
-      # fails to initialise at all: `Timed out while enabling automation mode`, zero tests executed —
-      # which reads like a broken suite rather than a missing permission. This is the supported way
-      # to pre-authorise it, and it is why the UI tests can run here at all.
-      - name: Allow UI automation without an interactive prompt
-        run: sudo automationmodetool enable-automationmode-without-authentication
-
-      # Tuist generates the workspace; nothing in the repo is a checked-in Xcode project.
-      #
-      # Pinned in `mise.toml`, not `brew install tuist`. Homebrew hands out whatever is current — it
-      # produced 4.202.6 against the 4.152.0 this project is developed on, and `tuist install` failed
-      # outright. A generator that silently tracks upstream turns "someone else released" into "our CI
-      # is red".
-      #
-      # The version lives in `mise.toml` rather than here because this action takes no `tools` input —
-      # passing one is accepted, warned about, and ignored, which installs nothing and leaves `tuist`
-      # off PATH for a step that then fails with exit 127.
-      - name: Install Tuist
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-
-      # Tuist resolves the SPM dependencies into the workspace, so this cache is what keeps a run
-      # from rebuilding Vapor and GRDB from source every time.
-      - name: Cache Tuist dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cache/tuist
-            Tuist/.build
-          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved', 'Project.swift') }}
-          restore-keys: ${{ runner.os }}-tuist-
-
-      # The macOS half of the same invariant. `tuist install` is a SwiftPM resolve behind another
-      # name, so it rewrites `Tuist/Package.resolved` on exactly the same trigger — a range that
-      # resolves differently on this runner than on the machine that committed it. It is checked
-      # here rather than in a step of its own so that it lands before `tuist generate`: the
-      # workspace every step below builds and tests is generated from whatever `install` resolved,
-      # and a lockfile that moved is a workspace that does not match the commit.
-      #
-      # This job has no counterpart to the Linux `Lockfiles agree` step because that check is
-      # platform-independent and running it twice buys nothing — but it means this line is the only
-      # thing standing between a re-resolved Tuist lockfile and a green run.
-      - name: Resolve and generate
-        run: |
-          tuist version
-          tuist install
-          git diff --exit-code -- Tuist/Package.resolved || {
-            echo "::error::tuist install re-resolved Tuist/Package.resolved (diff above). The workspace this job generated is not the one the commit describes. Reproduce with 'tuist install', commit the result, and move Package.resolved with it — Scripts/check_lockfiles.py is what says whether they still agree."
-            exit 1
-          }
-          tuist generate --no-open
-
-      # Tuist reports failures as an unhelpful "Error" and writes the reason to a session log the
-      # runner throws away. Without this a failure here says nothing at all.
-      - name: Tuist logs on failure
-        if: failure()
-        # Never the reason a run is red: this only ever explains one.
-        continue-on-error: true
-        run: |
-          find ~/.local/state/tuist/sessions -name logs.txt 2>/dev/null | while read -r f; do
-            echo "-- $f"
-            tail -100 "$f"
-          done
+      # Xcode and Swift versions, UI automation pre-authorised, Tuist at the pinned version, its
+      # cache restored, `Tuist/Package.resolved` held to the commit, and `tuist generate`. One copy,
+      # shared by this job and the four shards below — see the action's own header for why it is a
+      # file rather than seven steps pasted five times.
+      - uses: ./.github/actions/macos-setup
 
       # Ad-hoc signing throughout. The project carries a DEVELOPMENT_TEAM for local builds, but a
       # hosted runner has none of that team's certificates — and none are needed, because a macOS app
@@ -351,9 +430,10 @@ jobs:
             CODE_SIGN_IDENTITY=- build
 
       # Everything that needs Xcode but not a window: the app-level suites and the DesignSystem
-      # rendering tests. The rest of the suite already ran on Linux.
+      # rendering tests. The rest of the suite already ran on Linux, and XCUITest runs in the sharded
+      # job below — `-skip-testing:MimicUITests` is what keeps the two from overlapping.
       #
-      # This is also the only step in either job that *measures* how much of this code the tests
+      # This is also the only step in this workflow that *measures* how much of this code the tests
       # reach, rather than reading the tree and reasoning about it. Until it carried
       # `-enableCodeCoverage YES`, both README badges said `not measured` and meant it: every claim
       # in this repository about what is and is not tested rested on grep.
@@ -418,7 +498,7 @@ jobs:
       # (c): the same figures again, as a few hundred bytes of JSON handed to the `record-coverage`
       # job at the bottom of this file, which writes them into README.md.
       #
-      # A **job output**, not an artifact, and not three more lines on this job. Two constraints
+      # A **job output**, not an artifact, and not three more lines on that job. Two constraints
       # meet here. `contents: write` must not live on this job — it is the one that compiles and
       # runs code out of a pull request, and a write token here would widen the blast radius of
       # anything going wrong in that to "can push to `main`". And the `.xcresult` this reads is
@@ -457,79 +537,13 @@ jobs:
             echo 'COVERAGE_JSON_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      # The reason this job exists. XCUITest is the only thing that exercises the real window — the
-      # accessibility tree, the panel layout, and every flow a user actually takes.
-      #
-      # `-retry-tests-on-failure` is not papering over flakiness in the app: this suite launches the
-      # real app once per test, and a hosted runner under memory pressure will SIGKILL a random one.
-      # A retry distinguishes that from a genuine assertion failure, which fails again on the retry.
-      #
-      # What the retry does NOT do — observed on this job, 2026-08-14 — is turn the step green: a
-      # test that failed once and passed on the rerun (`testCapturingSelectedRequestsAsJourney`,
-      # final summary "Executed 28 tests, with 0 failures") still ended the step with "Failing
-      # tests:" naming it and exit 65. So red here means "failed at least once", not "failed".
-      # Before treating a red run as a hard break, read the tail: a listed failing test above a
-      # passing final suite summary is the retry having already told you it was transient — the
-      # step's value in that case is the flake's name, not the verdict.
-      - name: Test (UI)
-        run: |
-          xcodebuild -workspace Mimic.xcworkspace -scheme Mimic \
-            test -destination 'platform=macOS' -only-testing:MimicUITests \
-            -derivedDataPath "$DERIVED_DATA" \
-            -retry-tests-on-failure -test-iterations 2 \
-            CODE_SIGN_IDENTITY=-
-
-      # The failing assertion, in the job log, where a person can read it. The xcresult holds the
-      # message, the file and the line of every failure — and it ships as a ~280 MB artifact that
-      # needs a Mac and an Xcode to open, which in practice means nobody does: three consecutive red
-      # runs were diagnosed here from the *names* of failing tests alone, because the log's tail
-      # never reaches back to the assertion and the artifact was effectively opaque. `xcresulttool`
-      # exists on this runner, so ask it while we are here. `continue-on-error` on top of
-      # `if: failure()`: a diagnostic that can redden a run it was reading is worse than none.
-      - name: Test failure details
-        if: failure()
-        continue-on-error: true
-        run: |
-          # Both bundle locations, newest first. This used to look only under `$DERIVED_DATA`, which
-          # is where the UI suite writes — so on a *unit* failure, whose bundle the coverage step
-          # puts in `.artifacts/coverage`, the step it exists to serve printed "no xcresult found"
-          # and the assertion had to be read out of the raw log instead. Naming both is the whole
-          # fix; `ls -dt` across them picks whichever run actually failed.
-          # Compile errors first, because an xcresult cannot carry one. A test target that fails to
-          # build produces a bundle with `totalTestCount: 0` and no failures in it — so this step,
-          # written to name the failing assertion, printed a summary saying nothing at all while the
-          # actual errors sat in the build output. Two rounds of this wave were diagnosed by pulling
-          # the raw job log instead, which is the archaeology the step exists to replace.
-          if [ -f .artifacts/unit-tests.log ]; then
-            echo "== compile errors, if any"
-            grep -E '(error|fatal error): ' .artifacts/unit-tests.log | head -40 || echo "   none — the failure is in the results below"
-          fi
-          bundle="$(ls -dt "$DERIVED_DATA"/Logs/Test/*.xcresult .artifacts/coverage/*.xcresult 2>/dev/null | head -1)"
-          if [ -z "$bundle" ]; then echo "no xcresult found"; exit 0; fi
-          echo "== $bundle"
-          xcrun xcresulttool get test-results summary --path "$bundle" || true
-          # Every failure with its message, file and line — the part the job log's tail cannot show.
-          xcrun xcresulttool get test-results tests --path "$bundle" \
-            | python3 -c '
-          import json, sys
-          def walk(node, path):
-              name = node.get("name") or node.get("nodeIdentifier") or ""
-              here = path + [name] if name else path
-              if node.get("result") == "Failed" and node.get("nodeType") in ("Test Case", "Repetition"):
-                  print(" / ".join(here), "->", node.get("result"))
-              if node.get("nodeType") == "Failure Message":
-                  print("    ", name)
-              for child in node.get("children", []):
-                  walk(child, here)
-          data = json.load(sys.stdin)
-          for root in data.get("testNodes", []):
-              walk(root, [])
-          ' || true
-
-      # The seam nothing else in either job reaches: a real process launch, the discovery file on
+      # The seam nothing else in this workflow reaches: a real process launch, the discovery file on
       # disk, a real control socket, and `mimic` as a binary rather than `MimicCommand.run(arguments:)`
       # called in-process. AGENTS.md and CONTRIBUTING.md each carried a section explaining why no
       # gate ran it, and no runner ever had.
+      #
+      # It now runs about eighty minutes earlier than it used to, because it no longer waits behind
+      # XCUITest for a build it needed before the suite started.
       #
       # What kept it out was never safety, it was that it could not find what the job built. The
       # script resolves the CLI with `find … -path '*Build/Products*'`, which matches nothing while
@@ -600,6 +614,10 @@ jobs:
       # `mimic` tool — and it cannot land until somebody has seen the warning inventory, which is
       # what the step below now publishes on every run. Same order the coverage steps above follow:
       # measure first, gate second.
+      #
+      # It stays in this job rather than becoming a sixth, for the reason argued in the header: the
+      # cap is five concurrent macOS jobs, a job of its own would have to come out of the shards, and
+      # trading a shard for eight minutes lengthens the run rather than shortening it.
       - name: Build (Release)
         run: |
           set -o pipefail
@@ -642,43 +660,331 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # The result bundle is the only way to read a UI failure after the fact — it holds the failure
-      # screenshots and the automatic UI hierarchy captures.
+      # The failing assertion, in the job log, where a person can read it — compile errors out of the
+      # log first, because an xcresult cannot carry one, then every failure with its message, file
+      # and line out of whichever bundle is newest. The logic moved into
+      # `Scripts/print_test_failures.sh` when the UI suite was sharded: five test-running jobs would
+      # otherwise hold five pasted copies of the same forty-line walker, and a copy that has quietly
+      # stopped printing failures looks exactly like a run that had none.
       #
-      # Two paths now, because `-resultBundlePath` on the unit step *moves* that run's bundle out of
-      # DerivedData: the glob below would no longer find it, so it is named explicitly. It is also
-      # where the per-file coverage lives, for anyone who wants more than the per-target table in
-      # the summary. Still `if: failure()` — a coverage-instrumented bundle is large, and uploading
-      # one on every green run buys a reviewer nothing the summary has not already shown them.
+      # Both bundle locations are named. This used to look only under `$DERIVED_DATA`, which is where
+      # a plain `xcodebuild test` writes — so on a *unit* failure, whose bundle the step above puts in
+      # `.artifacts/coverage`, the step that exists to name the assertion printed "no xcresult found"
+      # and the assertion had to be read out of the raw log instead. The globs are expanded by this
+      # shell and the script skips whatever did not match, so a run that failed before a given
+      # artifact existed simply passes a path that is not there.
+      #
+      # It sits at the end of the job rather than immediately after the test step, which is where its
+      # ancestor sat. That is what puts a failing **Release** build in its scope: the release log is
+      # named below, so a compile error in the Release configuration now gets its `error:` lines
+      # pulled into the job log too, instead of the run going red with the reason a thousand lines up.
+      # Nothing else changes — a step with `if: failure()` runs when any earlier step failed, and
+      # every step between the failure and this one is skipped either way.
+      #
+      # `continue-on-error` on top of `if: failure()`: a diagnostic that can redden a run it was
+      # reading is worse than none.
+      - name: Test failure details
+        if: failure()
+        continue-on-error: true
+        run: |
+          ./Scripts/print_test_failures.sh \
+            .artifacts/unit-tests.log \
+            .artifacts/release-build.log \
+            "$DERIVED_DATA"/Logs/Test/*.xcresult \
+            .artifacts/coverage/*.xcresult
+
+      # The result bundle is where per-file coverage lives, for anyone who wants more than the
+      # per-target table in the summary, and on a red run it is the only place the failure detail
+      # survives in full.
+      #
+      # Named `xcresult-unit` rather than `xcresult`, because artifact names must be unique within a
+      # run and the four UI shards below each upload one of their own. Still `if: failure()` — a
+      # coverage-instrumented bundle is large, and uploading one on every green run buys a reviewer
+      # nothing the summary has not already shown them.
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: xcresult
+          name: xcresult-unit
           path: |
             ${{ env.DERIVED_DATA }}/Logs/Test/*.xcresult
             .artifacts/coverage/UnitTests.xcresult
           retention-days: 7
           if-no-files-found: ignore
 
-  # The one job in this workflow that writes to the repository. It records the coverage the macOS
-  # job measured into README.md's two badges and the block between its `coverage:generated`
-  # markers — the thing both badges spent this repository's whole history saying `not measured` for
-  # while the number was being computed on every run and thrown away with the runner.
+  # The reason this workflow exists at all, and the reason it used to take ninety-six minutes.
+  # XCUITest is the only thing that exercises the real window — the accessibility tree, the panel
+  # layout, and every flow a user actually takes.
+  #
+  # Four shards, four runners, four disjoint sets of test classes. The header of this file argues why
+  # sharding across machines rather than `-parallel-testing-enabled` on one, and why four rather than
+  # some other number; what follows is how the four were chosen.
+  #
+  # ## How the shards are balanced
+  #
+  # By **test count**, which is a proxy for time rather than time itself, and a defensible one here:
+  # nearly every test in these suites launches the app, so per-test cost is dominated by launch
+  # rather than by what the test then does. Counted from the tree — `grep -cE '^\s*func test'` over
+  # each file, the same convention `Scripts/check_doc_counts.py` uses — the ten classes are
+  #
+  #     MimicUITests               33      ErrorAlertUITests          15
+  #     WorkspaceShellUITests      27      JourneyEditorUITests       15
+  #     EndpointEditorUITests      24      SpecImportUITests          10
+  #     WelcomeProjectUITests      17      RequestLogUITests           9
+  #                                        JourneyUITests              7
+  #                                        ControlPlaneIsolationTests  1
+  #
+  # 158 in total, so a perfect quarter is 39.5. Longest-processing-time-first — take the classes
+  # largest to smallest and put each on the shard that is currently lightest — gives 40 / 38 / 39 /
+  # 41, which is within four percent of even and cannot be beaten by much given a 33-test class that
+  # cannot be split.
+  #
+  # **Whole classes, never individual tests.** `-only-testing:` accepts a method, and using it would
+  # let the shards be balanced to the test — but the split would then have to be rewritten every time
+  # somebody adds a test, and a shard naming a method that has been renamed fails with "no tests to
+  # run" rather than with anything a reader would connect to the rename. A class is a unit that moves
+  # as a whole.
+  #
+  # **The proxy is worth re-checking against real times once a few runs exist**, and the data is
+  # already in each shard's own result bundle. Download a shard's `xcresult-ui-N` artifact and ask
+  #
+  #     xcrun xcresulttool get test-results tests --path UITests.xcresult
+  #
+  # for the per-test durations, sum them by class, and rebalance by editing the `matrix` below —
+  # which is a one-line change per shard and needs nothing else in this file touched. Until somebody
+  # does, test count is the honest estimator and this comment is the record that it is an estimator.
+  #
+  # ## What each shard needs that a single job did not
+  #
+  # Nothing in `MimicUITests` changed to make this work, and that is the point. The suites already
+  # use disjoint port ranges and already suffix `MIMIC_CONTROL_FILE` with the runner's pid, so shards
+  # cannot collide on a socket or a discovery file — and the shared store and shared defaults domain,
+  # which are what make in-process parallelism impossible, are simply not shared between machines.
+  #
+  # The one thing that must survive is the UI target's entitlements: `MimicUITests.entitlements` sets
+  # `app-sandbox: false` and `network.server`, with `ENABLE_APP_SANDBOX: NO`, and four tests bind a
+  # listening socket from the test process. Nothing here overrides code signing beyond the
+  # `CODE_SIGN_IDENTITY=-` this workflow has always passed, so those entitlements are applied on each
+  # shard exactly as they were on the single job. If a shard reports EPERM on a bind, that is the
+  # first thing to look at.
+  macos-ui:
+    name: UI tests (${{ matrix.name }})
+    runs-on: macos-26
+    # A shard measures around 29 minutes: 1m35 setup, ~5m09 for the Debug build, ~1m30 to compile the
+    # test target, and ~20m of tests. Double it and round, so a shard that hits `-test-iterations 2`
+    # on several tests still finishes rather than being cut off mid-retry.
+    timeout-minutes: 60
+
+    strategy:
+      # Never `fail-fast`. The default would cancel the other three shards the moment one goes red,
+      # which turns "four independent verdicts" back into "one verdict, chosen by whichever shard
+      # failed first" — and the failure this suite is documented as producing most often is a
+      # SIGKILLed launch under memory pressure, which says nothing about the other three. A red run
+      # should say which parts of the window are broken, all of them, in one pass.
+      fail-fast: false
+      matrix:
+        include:
+          # 40 tests. `MimicUITests` is the original suite and the largest single class in the
+          # target; it goes on a shard of its own with only the seven-test journeys suite beside it.
+          - id: 1
+            name: core window and journeys
+            only: >-
+              -only-testing:MimicUITests/MimicUITests
+              -only-testing:MimicUITests/JourneyUITests
+
+          # 38 tests, and the lightest shard, which is why the one-test isolation class rides here:
+          # `ControlPlaneIsolationTests` launches the app like everything else, so it costs a launch
+          # wherever it lands, and the lightest shard is where a rounding error should go.
+          - id: 2
+            name: workspace shell, spec import, isolation
+            only: >-
+              -only-testing:MimicUITests/WorkspaceShellUITests
+              -only-testing:MimicUITests/SpecImportUITests
+              -only-testing:MimicUITests/ControlPlaneIsolationTests
+
+          # 39 tests.
+          - id: 3
+            name: endpoint editor and error alerts
+            only: >-
+              -only-testing:MimicUITests/EndpointEditorUITests
+              -only-testing:MimicUITests/ErrorAlertUITests
+
+          # 41 tests, the heaviest, and so the one to watch first if the estimate is wrong.
+          - id: 4
+            name: welcome, journey editor, request log
+            only: >-
+              -only-testing:MimicUITests/WelcomeProjectUITests
+              -only-testing:MimicUITests/JourneyEditorUITests
+              -only-testing:MimicUITests/RequestLogUITests
+
+    # Same reasoning as the job above: DerivedData inside the checkout, `.artifacts/` is gitignored,
+    # and the steps that read it read it from here.
+    env:
+      DERIVED_DATA: .artifacts/DerivedData
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/macos-setup
+
+      # No separate `Build (Debug)` step: `xcodebuild test` builds what the test action needs, and a
+      # shard needs nothing else. The build is not free — it is about five minutes of this shard's
+      # twenty-nine — but it runs on four machines at once, so it costs the *run* five minutes rather
+      # than twenty. That is the whole build-once-versus-build-per-shard argument, and it is made in
+      # full in this file's header.
+      #
+      # `-retry-tests-on-failure` is not papering over flakiness in the app: this suite launches the
+      # real app once per test, and a hosted runner under memory pressure will SIGKILL a random one.
+      # A retry distinguishes that from a genuine assertion failure, which fails again on the retry.
+      #
+      # What the retry does NOT do — observed on this suite, 2026-08-14 — is turn the step green: a
+      # test that failed once and passed on the rerun (`testCapturingSelectedRequestsAsJourney`,
+      # final summary "Executed 28 tests, with 0 failures") still ended the step with "Failing
+      # tests:" naming it and exit 65. So red here means "failed at least once", not "failed".
+      # Before treating a red shard as a hard break, read the tail: a listed failing test above a
+      # passing final suite summary is the retry having already told you it was transient — the
+      # step's value in that case is the flake's name, not the verdict.
+      #
+      # `$ONLY_TESTING` is deliberately unquoted: it carries several `-only-testing:` flags and the
+      # shell must split them into separate arguments. It reaches the shell through `env:` rather
+      # than as a `${{ }}` inside the script, which is the habit `record-coverage` explains at the
+      # bottom of this file — an expression interpolated into a `run:` is substituted before the
+      # shell sees it and is therefore parsed as script, while an environment variable can only ever
+      # be data. This value is written three inches above in the same file; the habit is the point.
+      #
+      # `-resultBundlePath` for the same reason the unit step names one, and with the shard id in the
+      # path so the four uploads below cannot collide. `tee` for the reason that step documents: a
+      # compile failure in the test target produces a bundle with `totalTestCount: 0`, so the errors
+      # exist only in this output.
+      - name: Test (UI)
+        env:
+          ONLY_TESTING: ${{ matrix.only }}
+          RESULT_BUNDLE: .artifacts/ui/UITests-${{ matrix.id }}.xcresult
+          BUILD_LOG: .artifacts/ui-tests-${{ matrix.id }}.log
+        run: |
+          set -o pipefail
+          rm -rf "$RESULT_BUNDLE"
+          mkdir -p .artifacts/ui
+          # shellcheck disable=SC2086
+          xcodebuild -workspace Mimic.xcworkspace -scheme Mimic \
+            test -destination 'platform=macOS' \
+            $ONLY_TESTING \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RESULT_BUNDLE" \
+            -retry-tests-on-failure -test-iterations 2 \
+            CODE_SIGN_IDENTITY=- 2>&1 | tee "$BUILD_LOG"
+
+      # The same diagnostic the non-UI job runs, over this shard's own log and bundle. It matters
+      # more here than there: the xcresult a UI failure leaves behind holds the failure screenshots
+      # and the automatic UI hierarchy captures, it is hundreds of megabytes, and reading it needs a
+      # Mac and an Xcode — so in practice the assertion this step prints is the only account of the
+      # failure anybody reads.
+      - name: Test failure details
+        if: failure()
+        continue-on-error: true
+        # Restated rather than inherited: `env:` on a step does not carry to the next one, and the
+        # two paths are the shard-numbered ones the step above wrote.
+        env:
+          RESULT_BUNDLE: .artifacts/ui/UITests-${{ matrix.id }}.xcresult
+          BUILD_LOG: .artifacts/ui-tests-${{ matrix.id }}.log
+        run: |
+          ./Scripts/print_test_failures.sh \
+            "$BUILD_LOG" \
+            "$RESULT_BUNDLE" \
+            "$DERIVED_DATA"/Logs/Test/*.xcresult
+
+      # One artifact per shard, named by shard id — `upload-artifact` refuses a duplicate name within
+      # a run, and four shards uploading `xcresult` would be four collisions. The name is also how a
+      # reader gets from "shard 3 is red" to the screenshots for shard 3 without downloading the
+      # other three.
+      #
+      # `if: failure()`, as before: these bundles are large and a green run's is worth nothing.
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: xcresult-ui-${{ matrix.id }}
+          path: |
+            .artifacts/ui/UITests-${{ matrix.id }}.xcresult
+            .artifacts/ui-tests-${{ matrix.id }}.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # One status check standing for all four shards.
+  #
+  # Each shard already fails the run on its own, so this job changes no verdict. What it buys is a
+  # **stable name**: branch protection requires checks by name, and `UI tests (core window and
+  # journeys)` is a name that changes the day somebody rebalances the matrix — at which point the
+  # required check silently refers to a job that no longer runs, and `main` starts accepting commits
+  # whose UI suite nobody looked at. Requiring `UI suite` instead survives any reshuffle of the
+  # shards, including changing how many there are.
+  #
+  # It runs on Linux and does nothing but read a result, so it costs no macOS slot and no measurable
+  # time.
+  #
+  # It reports *that* something is red, not *which* — deliberately. Telling a reader which shard
+  # failed would mean each shard publishing a marker and this job collecting them with
+  # `download-artifact`, which this workflow has never pinned and a SHA is not a thing to guess at.
+  # The run page already answers it: the four shards are named for the parts of the window they
+  # cover, and the red one is the red one.
+  #
+  # `!cancelled()` rather than `always()`. With `always()` this job would run after a pull request
+  # cancelled its own shards on a new push and report a failure caused by nothing, which is exactly
+  # the red-that-means-nothing this workflow keeps removing. A cancelled run skips it instead.
+  ui-suite:
+    name: UI suite
+    needs: macos-ui
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # `needs.<job>.result` over a matrix job is the roll-up of every leg: `success` only when all
+      # four passed, `failure` when any failed, `skipped` when the matrix never ran.
+      - name: Verdict
+        env:
+          RESULT: ${{ needs.macos-ui.result }}
+        run: |
+          set -euo pipefail
+          echo "The four UI shards rolled up to: $RESULT"
+          case "$RESULT" in
+            success)
+              echo "All four shards passed — 158 XCUITest cases across the four runners."
+              ;;
+            skipped)
+              echo "::error::The UI shards did not run, so nothing exercised the window on this commit."
+              exit 1
+              ;;
+            *)
+              echo "::error::At least one UI shard is red. Open the run page: the shards are named for the parts of the window they cover, and each uploads its own xcresult-ui-N artifact. Read the failing shard's 'Test failure details' step first — and note that -retry-tests-on-failure leaves the step red for a test that passed on its rerun, so a listed failure above a passing final summary is a flake, not a break."
+              exit 1
+              ;;
+          esac
+
+  # The one job in this workflow that writes to the repository. It records the coverage
+  # `macos-checks` measured into README.md's two badges and the block between its
+  # `coverage:generated` markers — the thing both badges spent this repository's whole history saying
+  # `not measured` for while the number was being computed on every run and thrown away with the
+  # runner.
   #
   # Why this is a separate job on Linux rather than three more lines on the macOS one is argued at
   # `Emit coverage figures` above: `contents: write` must not sit on the job that compiles and runs
   # code out of a pull request. What runs here is one stdlib Python script over one Markdown file.
   # No build, no test, no repository code executes.
   #
-  # `always()`, guarded to pushes on `main`. Coverage is measured two steps before XCUITest starts,
-  # and this repository's UI suite is documented as ending red on a test that passed on its retry —
-  # letting that decide whether the number is recorded would mean the README updates only on runs
-  # where a flake happened not to fire. A macOS job that died *before* the measurement leaves the
-  # output empty, which the first step below reports and stops on.
+  # **`needs: macos-checks`, not the UI shards, and that is now structural rather than a workaround.**
+  # It used to say `needs: macos` with `always()`, because coverage is measured two steps before
+  # XCUITest started and this repository's UI suite is documented as ending red on a test that passed
+  # on its retry — letting that decide whether the number is recorded would mean the README updates
+  # only on runs where a flake happened not to fire. Splitting the UI suite into its own job says the
+  # same thing in the dependency graph instead of in an `always()`: the job that measures coverage is
+  # the job this one waits for, and the shards are simply not upstream of it. `always()` is kept for
+  # the remaining case it covers — a `macos-checks` that died *before* the measurement leaves the
+  # output empty, which the first step below reports and stops on, rather than skipping this job with
+  # no explanation.
   record-coverage:
     name: Record coverage in README
-    needs: macos
+    needs: macos-checks
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
@@ -701,7 +1007,7 @@ jobs:
       - name: Write the figures out
         id: figures
         env:
-          COVERAGE_JSON: ${{ needs.macos.outputs.coverage }}
+          COVERAGE_JSON: ${{ needs.macos-checks.outputs.coverage }}
         run: |
           set -euo pipefail
           if [ -z "${COVERAGE_JSON:-}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,12 +788,25 @@ jobs:
   # run" rather than with anything a reader would connect to the rename. A class is a unit that moves
   # as a whole.
   #
-  # **Test count is still the estimator, and run #89 supports it rather than replacing it.** Its four
-  # shards ran 40 / 38 / 39 / 41 tests in 21m18 / 19m23 / 23m49 / ~22m — the ordering does not track
-  # the counts exactly (shard 3 ran fewer tests than shard 1 and took longer), so per-class cost is
-  # not perfectly uniform, but the spread of times is small enough that counting tests remains the
-  # honest cheap approximation. The constant that falls out is **~26 seconds per test**, from shard
-  # 3's 39 tests in a 22m42 step that also carries the build and the test-target compile.
+  # **Test count is a weaker estimator than it looked, and run #90 is the evidence.** Run #89's four
+  # shards ran 40 / 38 / 39 / 41 tests in 21m18 / 19m23 / 23m49 / ~22m, a spread small enough that
+  # counting seemed sound. Run #90's three ran 51 / 53 / 54 tests in **22m32 / 32m36 / 33m18** — four
+  # per cent more tests on the heaviest shard than the lightest, and forty-eight per cent more time.
+  #
+  # Subtract the build and test-target compile each step also carries (about seven minutes) and the
+  # per-test costs are roughly **17s / 28s / 28s**. The cheap shard is the one holding
+  # `SpecImportUITests`, which reads a bundled fixture and never starts a server, and the bulk of
+  # `MimicUITests`, which is mostly sheets and window state. The expensive shards hold the suites that
+  # bind a port and drive real HTTP — `RequestLogUITests` sends traffic for every assertion,
+  # `ErrorAlertUITests` holds sockets to force conflicts, `WorkspaceShellUITests` starts the server.
+  # **Launch is not the dominant cost after all; a real server is.**
+  #
+  # So the split below is balanced on the wrong axis, and knowingly. Rebalancing on measured time
+  # rather than count would put the worst shard near 28m30 instead of 33m18 — about five minutes,
+  # against a change that has to be re-derived every time a suite's character changes, and a run of
+  # this workflow to measure each attempt. The recipe is below and the data is in every run; take the
+  # five minutes when something else makes it worth a round trip. What must not happen is the next
+  # person reading "balanced by test count" and assuming the count was ever the thing that mattered.
   #
   # To do better than counting, the per-test data is already in each shard's own result bundle.
   # Download a shard's `xcresult-ui-N` artifact and ask

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ from the Debug products it just produced, checking both exist first.
 
 Run on its own after the commands above, it resolves both by searching again — those commands pass no
 `-derivedDataPath` either — so set `MIMIC_BIN` and `MIMIC_APP_PATH` yourself, or the green result is
-about a release you are not working on. The macOS CI job runs it too, but does not gate on it yet:
+about a release you are not working on. CI runs it too, in the `Build, unit suites, Release, CLI e2e
+(macOS)` job — where it now reports about eighty minutes earlier than it used to, because that job no
+longer waits behind the XCUITest suite — but does not gate on it yet:
 its first round there passed and its second failed at the discovery-file assertion, for a reason the
 app makes invisible — see the step's own comment in `.github/workflows/ci.yml`.
 

--- a/MimicUITests/RequestLogUITests.swift
+++ b/MimicUITests/RequestLogUITests.swift
@@ -1030,8 +1030,17 @@ final class RequestLogUITests: MimicUITestCase {
         )
         newJourneyItem.click()
 
+        // Fifteen seconds, not five, and this is the one wait in the file that needs them. Everything
+        // else here waits for an element that is already being drawn; this one waits for AppKit to
+        // tear down a *nested* menu and for SwiftUI to then present a sheet, two animations in series
+        // with a run loop handover between them. Run #91 spent longer than five seconds on exactly
+        // that and failed here — then passed on the retry, which is what says the sheet was coming
+        // and the clock was short rather than the capture being broken.
+        //
+        // Not a weakened assertion. A sheet that never appears still fails, and fails with this same
+        // message; the only thing the longer clock buys is not failing a machine that was busy.
         XCTAssertTrue(
-            captureSheet.nameField.waitForExistence(timeout: 5),
+            captureSheet.nameField.waitForExistence(timeout: 15),
             "Capturing into a new journey should ask for a name first"
         )
         captureSheet.nameField.click()

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ this is actually exercised" is a link away rather than a script somebody has to 
 Where to look: any run of [`.github/workflows/ci.yml`](.github/workflows/ci.yml), under the
 **Build, unit suites, Release, CLI e2e (macOS)** job's summary. Two things sit outside that
 measurement, both structurally: XCUITest, because the step doing the measuring is the one that skips
-it — the UI suite runs in four sharded jobs beside this one — and everything the Linux job runs,
+it — the UI suite runs in three sharded jobs beside this one — and everything the Linux job runs,
 because gathering coverage needs the Xcode toolchain. On a red run the bundle is uploaded as the
 `xcresult-unit` artifact, which is where per-file detail lives.
 
@@ -371,22 +371,26 @@ setting the floor against a baseline, is the order.
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
-`main`, in eight jobs across five definitions, and finishes in about **29 minutes**. Linux builds
+`main`, in seven jobs across five definitions, and finishes in about **30 minutes**. Linux builds
 `Package.swift`, runs the portable suites and every gate that needs no toolchain, in a couple of
 minutes. On macOS, `Build, unit suites, Release, CLI e2e` runs `tuist generate`, the Debug build, the
 app-level suites — measured, with the per-target coverage table printed into the job summary — the
-CLI end-to-end check and the Release gate, while **the XCUITest suite runs beside it in four shards
-on four runners**, rolled up into one `UI suite` status check. A short `record-coverage` job writes
+CLI end-to-end check and the Release gate, while **the XCUITest suite runs beside it in three shards
+on three runners**, rolled up into one `UI suite` status check. A short `record-coverage` job writes
 the coverage figures into this file on pushes to `main`.
 
 The suite is sharded across machines rather than parallelised on one because every UI test shares a
-store, a defaults domain, a window server and a frontmost application; four is the shard count
-because GitHub caps concurrent macOS jobs at five and the non-UI job takes the fifth slot. That split
-is a hand-maintained list of test classes, so
-[`Scripts/check_ui_shards.py`](Scripts/check_ui_shards.py) fails the Linux job if any class is run by
-no shard or by two — a class nobody runs would otherwise leave all four shards green. The workflow's
-own header argues all of it, including why each shard builds for itself instead of downloading one
-shared build. It used to be a single 96-minute job with XCUITest as four fifths of it.
+store, a defaults domain, a window server and a frontmost application; three is the shard count
+because the non-UI job takes one macOS slot and **four is how many concurrent macOS jobs this
+repository has actually been given**. GitHub documents five, and the first sharded run asked for
+five: run #89 started four jobs together and left the fifth queued for 19m26 — the length of a whole
+shard — which turned a predicted 29-minute run into a measured 43-minute one. Three shards of 51, 53
+and 54 tests fit the observed cap with nothing waiting. That split is a hand-maintained list of test
+classes, so [`Scripts/check_ui_shards.py`](Scripts/check_ui_shards.py) fails the Linux job if any
+class is run by no shard or by two — a class nobody runs would otherwise leave every shard green. The
+workflow's own header argues all of it, including why each shard builds for itself instead of
+downloading one shared build. It used to be a single 96-minute job with XCUITest as four fifths of
+it.
 
 Both runners are free on a public repository. (This section used to say Actions could not start
 a job here at all — true while the repository was private and a billing block killed every run in

--- a/README.md
+++ b/README.md
@@ -321,10 +321,11 @@ writes its result bundle to a named path; the `Coverage report` step reads that 
 this is actually exercised" is a link away rather than a script somebody has to remember to run.
 
 Where to look: any run of [`.github/workflows/ci.yml`](.github/workflows/ci.yml), under the
-**Build and test (macOS)** job's summary. Two things sit outside that measurement, both
-structurally: XCUITest, because the step doing the measuring is the one that skips it, and everything
-the Linux job runs, because gathering coverage needs the Xcode toolchain. On a red run the bundle is
-uploaded as the `xcresult` artifact, which is where per-file detail lives.
+**Build, unit suites, Release, CLI e2e (macOS)** job's summary. Two things sit outside that
+measurement, both structurally: XCUITest, because the step doing the measuring is the one that skips
+it — the UI suite runs in four sharded jobs beside this one — and everything the Linux job runs,
+because gathering coverage needs the Xcode toolchain. On a red run the bundle is uploaded as the
+`xcresult-unit` artifact, which is where per-file detail lives.
 
 **The numbers are also recorded here, on every push to `main`.** They used to exist only in that job
 summary — computed on every run and thrown away with the runner — which is why both badges above
@@ -335,10 +336,10 @@ output, and that job rewrites the two badges and the block below with
 
 Four things about it are deliberate, and each is the answer to a way this normally goes wrong:
 
-- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS job
-  compiles and runs code out of a pull request; a write token there would widen the blast radius of
-  anything going wrong in it to "can push to `main`". The recording job runs one Python script over
-  one Markdown file.
+- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS
+  jobs compile and run code out of a pull request; a write token there would widen the blast radius
+  of anything going wrong in one to "can push to `main`". The recording job runs one Python script
+  over one Markdown file.
 - **A few hundred bytes cross between them, not the bundle.** The `.xcresult` is hundreds of
   megabytes and stays on the runner that made it.
 - **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
@@ -370,11 +371,24 @@ setting the floor against a baseline, is the order.
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
-`main`, in three jobs: Linux builds `Package.swift` and runs the portable suites in a couple of
-minutes, macOS runs `tuist generate`, the Debug build, the app-level suites — measured, with the
-per-target coverage table printed into the job summary — XCUITest and the Release gate, and a short
-`record-coverage` job writes those figures into this file on pushes to `main`. Both runners
-are free on a public repository. (This section used to say Actions could not start
+`main`, in eight jobs across five definitions, and finishes in about **29 minutes**. Linux builds
+`Package.swift`, runs the portable suites and every gate that needs no toolchain, in a couple of
+minutes. On macOS, `Build, unit suites, Release, CLI e2e` runs `tuist generate`, the Debug build, the
+app-level suites — measured, with the per-target coverage table printed into the job summary — the
+CLI end-to-end check and the Release gate, while **the XCUITest suite runs beside it in four shards
+on four runners**, rolled up into one `UI suite` status check. A short `record-coverage` job writes
+the coverage figures into this file on pushes to `main`.
+
+The suite is sharded across machines rather than parallelised on one because every UI test shares a
+store, a defaults domain, a window server and a frontmost application; four is the shard count
+because GitHub caps concurrent macOS jobs at five and the non-UI job takes the fifth slot. That split
+is a hand-maintained list of test classes, so
+[`Scripts/check_ui_shards.py`](Scripts/check_ui_shards.py) fails the Linux job if any class is run by
+no shard or by two — a class nobody runs would otherwise leave all four shards green. The workflow's
+own header argues all of it, including why each shard builds for itself instead of downloading one
+shared build. It used to be a single 96-minute job with XCUITest as four fifths of it.
+
+Both runners are free on a public repository. (This section used to say Actions could not start
 a job here at all — true while the repository was private and a billing block killed every run in
 about two seconds; making it public resolved it.)
 

--- a/Scripts/check_ui_shards.py
+++ b/Scripts/check_ui_shards.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 """Fails when a UI test class is not run by any CI shard, or is run by more than one.
 
-`.github/workflows/ci.yml` shards the XCUITest suite across four macOS runners, and it does so by
+`.github/workflows/ci.yml` shards the XCUITest suite across three macOS runners, and it does so by
 naming test classes: each shard passes a list of `-only-testing:MimicUITests/<Class>` flags and runs
 exactly those. That is the only workable split — the suites share one store, one defaults domain and
 one window server, so `-parallel-testing-enabled` on a single machine is not available here, and the
 workflow's header argues that at length.
 
+Nothing below hard-codes that three. The shard list, the shard count and the per-shard totals are all
+derived from the workflow text, which is what let the split go from four shards to three — after run
+#89 measured the concurrent-macOS-job cap at four rather than the documented five — with this file's
+logic untouched and only this paragraph and the one above it edited.
+
 It also introduces a failure mode the single job did not have, and it is the worst kind: **a UI test
 class that no shard names simply never runs, and every shard is green.** Add `SettingsUITests.swift`
-tomorrow, write twenty tests in it, push, and four green checks report that the window is covered.
+tomorrow, write twenty tests in it, push, and three green checks report that the window is covered.
 Nothing in `xcodebuild` can notice — a shard asked for the classes it was given and got them — and
 nothing in the workflow can either, because the workflow is the thing that is wrong.
 

--- a/Scripts/check_ui_shards.py
+++ b/Scripts/check_ui_shards.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Fails when a UI test class is not run by any CI shard, or is run by more than one.
+
+`.github/workflows/ci.yml` shards the XCUITest suite across four macOS runners, and it does so by
+naming test classes: each shard passes a list of `-only-testing:MimicUITests/<Class>` flags and runs
+exactly those. That is the only workable split — the suites share one store, one defaults domain and
+one window server, so `-parallel-testing-enabled` on a single machine is not available here, and the
+workflow's header argues that at length.
+
+It also introduces a failure mode the single job did not have, and it is the worst kind: **a UI test
+class that no shard names simply never runs, and every shard is green.** Add `SettingsUITests.swift`
+tomorrow, write twenty tests in it, push, and four green checks report that the window is covered.
+Nothing in `xcodebuild` can notice — a shard asked for the classes it was given and got them — and
+nothing in the workflow can either, because the workflow is the thing that is wrong.
+
+This repository has met that shape before. `Project.swift` carried a `buildableFolders` line naming
+`Tests/JourneyFeatureTests` with no directory behind it, which Tuist tolerated silently while the
+manifest read as though the journey UI had tests; `Scripts/check_doc_counts.py` exists partly to fail
+on a suite folder that no manifest declares, "which on a green pipeline is indistinguishable from one
+that passed". This is the same sentence with `-only-testing:` in place of `buildableFolders`.
+
+So the shard list is checked against the tree rather than trusted:
+
+  - a class with at least one `func test…` in `MimicUITests/` that appears in **no** shard fails;
+  - a class named by **two** shards fails, because it would be run twice and the balance the shards
+    were chosen for is wrong by that much;
+  - a shard naming a class that **does not exist** fails, which is what a rename leaves behind —
+    `xcodebuild` reports it as "no tests to run" and exits 0, so the shard goes green having run
+    nothing.
+
+It reads the workflow as text and the suites as text. Nothing here imports PyYAML: the Linux CI job
+installs `python3-minimal` and has no third-party packages at all, which is a constraint every
+checker in `Scripts/` states in its own header so that it stays true. Regex over
+`-only-testing:MimicUITests/<Class>` is enough, because that string is the whole interface between
+the workflow and the suite.
+
+`--self-test` drives all four verdicts over fixtures written in this file — a workflow and a suite
+tree invented here, never read off disk and never produced by the functions under test. That is the
+rule AGENTS.md states as one question: if I revert the mechanism this test is for, does this test go
+red? A fixture derived from the parsers would move with them and the answer would be no.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+UI_TESTS = ROOT / "MimicUITests"
+
+# The target name is part of the flag, and part of what makes this checkable: `-only-testing:` takes
+# `<target>/<class>` and this repository has exactly one UI target.
+TARGET = "MimicUITests"
+
+ONLY_TESTING = re.compile(r"-only-testing:" + TARGET + r"/([A-Za-z_][A-Za-z0-9_]*)")
+
+# A class declaration at the start of a line, with a superclass. Page objects in this target are
+# `struct`s and are correctly invisible to this; a `class` with no superclass is not an XCTestCase
+# either. The `func test…` count below is the real filter — `MimicUITestCase` is a `class` with a
+# superclass and zero tests, and XCTest runs nothing in it.
+CLASS_DECL = re.compile(r"^(?:final\s+|public\s+|open\s+)*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*:")
+
+# Indented, because a top-level `func test…` is not a test method. The same convention
+# `Scripts/check_doc_counts.py` counts by, and the one README.md documents.
+TEST_FUNC = re.compile(r"^\s+(?:@\w+\s+)*(?:final\s+|public\s+|private\s+|internal\s+)*func\s+test")
+
+
+def shard_classes(workflow_text):
+    """Every class named by an `-only-testing:` flag, in order, duplicates kept.
+
+    Order and duplicates both matter: the caller reports a class named twice, and it can only do
+    that if this does not deduplicate on the way past.
+    """
+    return ONLY_TESTING.findall(workflow_text)
+
+
+def suite_classes(sources):
+    """`{class name: test count}` for every class in `sources` that declares at least one test.
+
+    `sources` is an iterable of `(filename, text)` so the caller decides whether that comes from
+    disk or from a fixture. A file may hold more than one class; each `func test…` is attributed to
+    the most recent declaration above it.
+    """
+    counts = {}
+    for _name, text in sources:
+        current = None
+        for line in text.splitlines():
+            declared = CLASS_DECL.match(line)
+            if declared:
+                current = declared.group(1)
+                counts.setdefault(current, 0)
+                continue
+            if current and TEST_FUNC.match(line):
+                counts[current] += 1
+    return {name: n for name, n in counts.items() if n > 0}
+
+
+def check(workflow_text, sources):
+    """Returns `(problems, sharded, tests)` — a list of strings, the shard list, the counts."""
+    sharded = shard_classes(workflow_text)
+    tests = suite_classes(sources)
+    problems = []
+
+    seen = set()
+    for name in sharded:
+        if name in seen:
+            problems.append(
+                f"{TARGET}/{name} is named by more than one shard: it would run twice, and the "
+                f"balance the shards were chosen for is wrong by that much."
+            )
+        seen.add(name)
+
+    for name in sorted(seen - set(tests)):
+        problems.append(
+            f"{TARGET}/{name} is named by a shard in .github/workflows/ci.yml but declares no "
+            f"tests — a renamed or deleted class. xcodebuild reports this as 'no tests to run' and "
+            f"exits 0, so the shard goes green having run nothing."
+        )
+
+    for name in sorted(set(tests) - seen):
+        problems.append(
+            f"{TARGET}/{name} declares {tests[name]} test(s) and no shard in "
+            f".github/workflows/ci.yml runs it. Add an -only-testing:{TARGET}/{name} line to the "
+            f"lightest shard's `only:` list."
+        )
+
+    return problems, sharded, tests
+
+
+def report_balance(workflow_text, tests):
+    """Prints the per-shard totals. Informational — an imbalance is never a failure.
+
+    Test count is a proxy for time and the workflow says so; a spread this prints is a prompt to go
+    and look at the real per-test durations in a shard's result bundle, not a verdict on anything.
+    """
+    # A shard is a `- id: N` entry, and its flags are the `-only-testing:` lines before the next one.
+    blocks = re.split(r"^\s*- id:\s*", workflow_text, flags=re.MULTILINE)[1:]
+    if not blocks:
+        return
+    totals = []
+    for block in blocks:
+        shard_id = block.split("\n", 1)[0].strip()
+        names = ONLY_TESTING.findall(block)
+        if not names:
+            continue
+        totals.append((shard_id, sum(tests.get(n, 0) for n in names), names))
+    if not totals:
+        return
+
+    print(f"UI shards ({sum(n for _i, n, _c in totals)} tests across {len(totals)}):")
+    for shard_id, total, names in totals:
+        print(f"  shard {shard_id}: {total:3d}  {', '.join(names)}")
+    heaviest = max(n for _i, n, _c in totals)
+    lightest = min(n for _i, n, _c in totals)
+    if lightest and heaviest > lightest * 1.5:
+        print(
+            f"  note: the heaviest shard carries {heaviest} tests against the lightest's "
+            f"{lightest}. Worth rebalancing the matrix — see the comment above `macos-ui` in "
+            f".github/workflows/ci.yml for how to do it from measured durations."
+        )
+
+
+# --- self-test ---------------------------------------------------------------------------------
+#
+# Fixtures written out here as literals, never read from the repository and never produced by the
+# functions above. A checker whose self-test asks the parsers what the right answer is certifies
+# whatever they currently do, including doing nothing.
+
+GOOD_WORKFLOW = """
+      matrix:
+        include:
+          - id: 1
+            only: >-
+              -only-testing:MimicUITests/AlphaUITests
+              -only-testing:MimicUITests/BetaUITests
+          - id: 2
+            only: >-
+              -only-testing:MimicUITests/GammaUITests
+"""
+
+GOOD_SOURCES = [
+    ("Alpha.swift", "final class AlphaUITests: MimicUITestCase {\n    func testOne() {}\n"),
+    (
+        "Beta.swift",
+        "final class BetaUITests: XCTestCase {\n    func testOne() {}\n    func testTwo() {}\n",
+    ),
+    ("Gamma.swift", "final class GammaUITests: XCTestCase {\n    func testOne() {}\n"),
+    # A base class with no tests, and a page object. Neither is runnable, and a checker that
+    # demanded a shard for either would be red on a tree that is correct.
+    ("Base.swift", "class MimicUITestCase: XCTestCase {\n    func setUpWithError() throws {}\n"),
+    ("Pages.swift", "struct WelcomePage {\n    func testable() {}\n"),
+]
+
+
+def self_test():
+    failures = []
+
+    def expect(label, condition, detail=""):
+        if condition:
+            print(f"  ok   {label}")
+        else:
+            print(f"  FAIL {label} {detail}")
+            failures.append(label)
+
+    print("check_ui_shards.py --self-test")
+
+    problems, sharded, tests = check(GOOD_WORKFLOW, GOOD_SOURCES)
+    expect("a complete, non-overlapping split passes", problems == [], problems)
+    expect(
+        "only classes that declare tests are counted",
+        tests == {"AlphaUITests": 1, "BetaUITests": 2, "GammaUITests": 1},
+        tests,
+    )
+    expect("every shard flag is found", len(sharded) == 3, sharded)
+
+    # A class on disk that no shard names — the failure this file exists for.
+    unsharded = GOOD_SOURCES + [
+        ("Delta.swift", "final class DeltaUITests: XCTestCase {\n    func testOne() {}\n")
+    ]
+    problems, _s, _t = check(GOOD_WORKFLOW, unsharded)
+    expect(
+        "a class no shard runs fails",
+        len(problems) == 1 and "DeltaUITests" in problems[0] and "no shard" in problems[0],
+        problems,
+    )
+
+    # The same class on two shards.
+    doubled = GOOD_WORKFLOW + "              -only-testing:MimicUITests/AlphaUITests\n"
+    problems, _s, _t = check(doubled, GOOD_SOURCES)
+    expect(
+        "a class named by two shards fails",
+        len(problems) == 1 and "more than one shard" in problems[0],
+        problems,
+    )
+
+    # A shard naming a class that is not there — what a rename leaves behind.
+    renamed = [s for s in GOOD_SOURCES if s[0] != "Gamma.swift"]
+    problems, _s, _t = check(GOOD_WORKFLOW, renamed)
+    expect(
+        "a shard naming a class that does not exist fails",
+        len(problems) == 1 and "GammaUITests" in problems[0] and "declares no tests" in problems[0],
+        problems,
+    )
+
+    # A workflow that has stopped naming any class at all. Every class is then unsharded, which is
+    # the loud version of the quiet failure — worth pinning, because a checker that reported "all
+    # clear" against an empty flag list would be agreeing with nothing.
+    problems, _s, _t = check("matrix:\n  include: []\n", GOOD_SOURCES)
+    expect("an empty shard list fails for every class", len(problems) == 3, problems)
+
+    if failures:
+        print(f"\n{len(failures)} self-test failure(s). The checker is not trustworthy — fix it "
+              f"before reading anything it says about the tree.")
+        return 1
+    print("  self-test passed\n")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv[1:]:
+        return self_test()
+
+    if not WORKFLOW.is_file():
+        print(f"error: {WORKFLOW} does not exist", file=sys.stderr)
+        return 1
+    if not UI_TESTS.is_dir():
+        print(f"error: {UI_TESTS} does not exist", file=sys.stderr)
+        return 1
+
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    sources = [(p.name, p.read_text(encoding="utf-8")) for p in sorted(UI_TESTS.glob("*.swift"))]
+
+    problems, sharded, tests = check(workflow_text, sources)
+
+    # A tree with no UI tests, or a workflow with no shards, is not "clean" — it is a checker with
+    # nothing to compare, which is the state every silently-passing gate in this repository was in.
+    if not tests:
+        print("error: no test classes found under MimicUITests/ — this checker compared nothing.",
+              file=sys.stderr)
+        return 1
+    if not sharded:
+        print("error: no -only-testing:MimicUITests/... flags in .github/workflows/ci.yml — either "
+              "the UI suite stopped being sharded, in which case delete this checker, or the flag "
+              "spelling changed and this compared nothing.", file=sys.stderr)
+        return 1
+
+    report_balance(workflow_text, tests)
+
+    if problems:
+        print()
+        for problem in problems:
+            print(f"error: {problem}", file=sys.stderr)
+        return 1
+
+    print(f"\nEvery one of the {len(tests)} UI test classes is run by exactly one shard.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/ci.sh
+++ b/Scripts/ci.sh
@@ -24,12 +24,12 @@
 #     `automationmodetool enable-automationmode-without-authentication`, which is what lets XCUITest
 #     drive another app with nobody at the keyboard.
 #
-#   - **The UI suite runs here in one pass, and on CI in four shards on four machines.** This laptop
+#   - **The UI suite runs here in one pass, and on CI in three shards on three machines.** This laptop
 #     is one machine, and the reason CI shards at all is that these suites cannot share one: they
 #     share `mimic-uitests.sqlite`, the `com.devxa.Mimic.UITests` defaults domain, and — being a real
 #     macOS app rather than a simulator — one window server and one frontmost application. So the
 #     serial run below is not a slower version of what CI does, it is the only version available
-#     locally, and it takes about eighty minutes against CI's twenty-nine. Two consequences worth
+#     locally, and it takes about eighty minutes against CI's thirty. Two consequences worth
 #     knowing. Running the whole target in one pass means a suite that no CI shard names still passes
 #     here — which is why `Scripts/check_ui_shards.py` runs below, as the only thing that can see
 #     that gap from a laptop. And a shard-ordering effect, if one ever appears, cannot reproduce
@@ -291,11 +291,11 @@ step "Skill layout"
 python3 Scripts/check_skills.py
 
 # The fourth, and it guards the workflow rather than a document. CI shards the XCUITest suite across
-# four macOS runners by naming test classes — each shard passes its own list of
+# three macOS runners by naming test classes — each shard passes its own list of
 # `-only-testing:MimicUITests/<Class>` flags — because the suites share one store, one defaults
 # domain and one window server, so parallel workers on a single machine would destroy each other's
 # state. That split is a hand-maintained list, and the way it fails is silent: a class no shard names
-# never runs, and all four shards go green having each run exactly what they were asked for.
+# never runs, and every shard goes green having each run exactly what it was asked for.
 #
 # It matters more here than most of these checks, because this script's own `UI tests` step above
 # runs the whole target in one pass. A suite added today passes locally and is invisible on CI, which

--- a/Scripts/ci.sh
+++ b/Scripts/ci.sh
@@ -3,7 +3,7 @@
 #
 # Exists so the gate is reproducible on a laptop — useful before pushing, and essential while the
 # hosted runners are unavailable. It used to open by claiming it "runs exactly what CI runs", which
-# was false in a way that mattered, so here is the precise version. Three differences, none of them
+# was false in a way that mattered, so here is the precise version. Four differences, none of them
 # fixable from inside this file:
 #
 #   - **`swift test` runs on this machine, not in the `swift:6.2` container.** Same sources, a
@@ -23,6 +23,17 @@
 #   - **Runner setup is absent**, because it is not a gate: the SwiftPM and Tuist caches, and
 #     `automationmodetool enable-automationmode-without-authentication`, which is what lets XCUITest
 #     drive another app with nobody at the keyboard.
+#
+#   - **The UI suite runs here in one pass, and on CI in four shards on four machines.** This laptop
+#     is one machine, and the reason CI shards at all is that these suites cannot share one: they
+#     share `mimic-uitests.sqlite`, the `com.devxa.Mimic.UITests` defaults domain, and — being a real
+#     macOS app rather than a simulator — one window server and one frontmost application. So the
+#     serial run below is not a slower version of what CI does, it is the only version available
+#     locally, and it takes about eighty minutes against CI's twenty-nine. Two consequences worth
+#     knowing. Running the whole target in one pass means a suite that no CI shard names still passes
+#     here — which is why `Scripts/check_ui_shards.py` runs below, as the only thing that can see
+#     that gap from a laptop. And a shard-ordering effect, if one ever appears, cannot reproduce
+#     here at all.
 #
 # Everything else is the same command with the same flags, ad-hoc signing included. The three
 # manifest checks are the same *program*, not a copy of it: `Scripts/check_lockfiles.py`,
@@ -278,6 +289,20 @@ python3 Scripts/check_doc_counts.py
 # read, which is the same failure mode as a house rule kept only by review.
 step "Skill layout"
 python3 Scripts/check_skills.py
+
+# The fourth, and it guards the workflow rather than a document. CI shards the XCUITest suite across
+# four macOS runners by naming test classes — each shard passes its own list of
+# `-only-testing:MimicUITests/<Class>` flags — because the suites share one store, one defaults
+# domain and one window server, so parallel workers on a single machine would destroy each other's
+# state. That split is a hand-maintained list, and the way it fails is silent: a class no shard names
+# never runs, and all four shards go green having each run exactly what they were asked for.
+#
+# It matters more here than most of these checks, because this script's own `UI tests` step above
+# runs the whole target in one pass. A suite added today passes locally and is invisible on CI, which
+# is the one direction a local gate cannot warn about by simply being run.
+step "UI shards cover every UI test class"
+python3 Scripts/check_ui_shards.py --self-test
+python3 Scripts/check_ui_shards.py
 
 # The end-to-end check, which used to be listed here as deliberately *not* run.
 #

--- a/Scripts/print_test_failures.sh
+++ b/Scripts/print_test_failures.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Prints the failing assertion — message, file and line — out of an `.xcresult`, plus any compiler
+# errors out of a build log, into whatever is reading stdout.
+#
+# This is the step `.github/workflows/ci.yml` runs when a test job goes red, and it exists because
+# the alternative is nothing. The result bundle holds every failure's message, file and line, and it
+# ships as a several-hundred-megabyte artifact that needs a Mac and an Xcode to open — which in
+# practice means nobody does: three consecutive red runs in this repository were diagnosed from the
+# *names* of failing tests alone, because the job log's tail never reaches back to the assertion and
+# the artifact was effectively opaque.
+#
+# It is a file rather than forty lines pasted into each job because the UI suite is now sharded and
+# there are five test-running macOS jobs. Five pasted copies of an embedded Python walker is the
+# duplication AGENTS.md names outright — a rule written twice is a rule that will drift — and this
+# one is worth even less duplicated, because a copy that has silently stopped printing failures is
+# indistinguishable from a run that had none.
+#
+# Usage:
+#
+#     Scripts/print_test_failures.sh [path …]
+#
+# Each argument is classified by its suffix and missing paths are skipped, so a caller may pass a
+# glob that matched nothing:
+#
+#     *.log        a build/test log, grepped for compiler errors
+#     *.xcresult   a candidate result bundle; the newest one that exists is the one summarised
+#
+# **Compiler errors are printed first, before any bundle.** An xcresult cannot carry one: a test
+# target that fails to build produces a bundle with `totalTestCount: 0` and no failures in it, so a
+# reader looking only at the bundle sees a summary saying nothing at all while the actual errors sit
+# in the build output. Two rounds of one wave here were diagnosed by pulling the raw job log
+# instead, which is the archaeology this script exists to replace.
+#
+# **It always exits 0.** A diagnostic that can redden the run it was reading is worse than none —
+# the same argument the coverage steps in the workflow make for themselves. The callers pass
+# `continue-on-error: true` as well; this is the half of that promise which survives being run by
+# hand on a laptop.
+
+# No `set -e`: every command below is allowed to fail. `pipefail` is off for the same reason, and
+# where a pipeline's status would otherwise be misread the result is captured into a variable
+# instead — see the compiler-error grep, whose `grep … | head -40 || echo "none"` ancestor could
+# never print its fallback, because the `||` was testing `head`'s status and `head` always succeeds.
+set -u
+
+logs=()
+bundles=()
+
+for arg in "$@"; do
+    case "$arg" in
+        *.log)      [ -f "$arg" ] && logs+=("$arg") ;;
+        *.xcresult) [ -e "$arg" ] && bundles+=("$arg") ;;
+        *)          echo "print_test_failures.sh: ignoring '$arg' (expected *.log or *.xcresult)" ;;
+    esac
+done
+
+for log in ${logs+"${logs[@]}"}; do
+    echo "== compile errors in $log, if any"
+    errors="$(grep -E '(error|fatal error): ' "$log" | head -40)"
+    if [ -n "$errors" ]; then
+        printf '%s\n' "$errors"
+    else
+        echo "   none — the failure is in the results below"
+    fi
+done
+
+if [ "${#bundles[@]}" -eq 0 ]; then
+    echo "no xcresult found"
+    exit 0
+fi
+
+# Newest first. A job may hand over more than one candidate — the unit job writes its bundle to a
+# named path under `.artifacts/` while xcodebuild also leaves one in DerivedData — and the one that
+# matters is whichever run actually failed.
+#
+# `ls -dt` rather than `find`, and the suppression is deliberate rather than a shrug. SC2012 is about
+# filenames a line-oriented parse would mangle; every path here is an `.xcresult` this workflow chose
+# the name of, two directories deep in a checkout. The portable alternative is not available: sorting
+# by mtime with `find` needs `-printf`, which is a GNU extension, and this only ever runs on macOS,
+# whose BSD `find` does not have it.
+# shellcheck disable=SC2012
+bundle="$(ls -dt "${bundles[@]}" 2>/dev/null | head -1)"
+echo "== $bundle"
+
+xcrun xcresulttool get test-results summary --path "$bundle" || true
+
+# Every failure with its message, file and line — the part the job log's tail cannot show.
+xcrun xcresulttool get test-results tests --path "$bundle" \
+    | python3 -c '
+import json, sys
+def walk(node, path):
+    name = node.get("name") or node.get("nodeIdentifier") or ""
+    here = path + [name] if name else path
+    if node.get("result") == "Failed" and node.get("nodeType") in ("Test Case", "Repetition"):
+        print(" / ".join(here), "->", node.get("result"))
+    if node.get("nodeType") == "Failure Message":
+        print("    ", name)
+    for child in node.get("children", []):
+        walk(child, here)
+data = json.load(sys.stdin)
+for root in data.get("testNodes", []):
+    walk(root, [])
+' || true
+
+exit 0


### PR DESCRIPTION
## ⚠️ One thing needs you, before or right after merge

**Branch protection has to be updated by hand.** Required checks are configured by job *name*, and `Build and test (macOS)` no longer exists. Until the required list names the new jobs, `main` will silently accept commits with **no macOS check required at all** — the most dangerous shape of failure this PR could have, because it looks like everything is fine.

- `Build, unit suites, Release, CLI e2e (macOS)`
- `UI suite`

Require `UI suite`, not the individual `UI tests (…)` legs: it is a fixed name that rolls the matrix up, so the required list survives a change in shard count. That property is no longer theoretical — this PR changed the shard count from four to three mid-review and the roll-up absorbed it.

## Measured

| | before | after |
|---|--:|--:|
| Critical path | **96 min** | **33–36 min** (~2.8×) |
| First red signal (compile / unit) | 96 min | **~8 min** |

Two green runs at three shards: **33m 25s** (#90, clean) and **35m 46s** (#92, one test retried). Run #89 verified the same machinery at four shards.

Per-job, from run #90:

| Job | Tests | Duration |
|---|--:|--:|
| Linux | — | 2m 03s |
| `macos-checks` | — | 22m 06s |
| UI shard — core window, journeys, spec import | 51 | 22m 32s |
| UI shard — workspace shell, welcome, request log | 53 | 32m 36s |
| UI shard — endpoint editor, alerts, journey editor | 54 | 33m 18s |
| `ui-suite` roll-up | — | 3s |
| **Total** | **158** | **33m 25s** |

All four macOS jobs started within one second of each other. Nothing queued.

## Three things this PR learned by running, and wrote down

**1. The concurrent macOS cap is 4 here, not the documented 5.** The first revision budgeted one `macos-checks` plus four shards against GitHub's documented five. Run #89 was green but took **43 minutes**: four macOS jobs started at 22:01:49 and the fifth at **22:21:15** — 19m26 later, two seconds after another freed a slot. The whole miss was one job in a queue. Three shards make it exactly four concurrent.

Recorded with its timestamps and framed as what was observed, not as a correction to the docs — the difference may be this account, plan or runner pool. One run is enough to design against and not enough to call the documentation wrong.

**2. Test count is a weak proxy for shard time — a real server costs more than a launch.** The shards are balanced by count, reasoning that nearly every test launches the app so launch dominates. Run #90 refutes it: 51 / 53 / 54 tests took 22m32 / 32m36 / 33m18. Four per cent more tests on the heaviest shard, forty-eight per cent more time. Net of build and compile, ~17s per test on one shard and ~28s on the others.

The cheap shard holds `SpecImportUITests`, which reads a bundled fixture and never starts a server, plus the bulk of `MimicUITests`, which is mostly sheets and window state. The expensive shards hold the suites that bind a port and drive real HTTP.

**Rebalancing on measured time would reach ~28m30 instead of 33m18.** Those five minutes are deliberately left: the change must be re-derived whenever a suite's character changes, and costs a full run to measure each attempt. The recipe and the data location are in the matrix comment. What the comment must not do is let the next reader believe the count was ever the thing that mattered — so it now says plainly that it was not.

**3. A flake reddens a shard even when the retry passes.** Run #91 failed `RequestLogUITests.testAddingRequestsToAnExistingJourneyFromTheLog`, retried it, and passed — 52 tests, 53 runs, a final iteration summary reading zero failures above a `Failing tests:` line naming that one, and exit 65 anyway. That is pre-existing `-retry-tests-on-failure` behaviour this workflow already documented, not something sharding introduced.

The specific flake is fixed: the assertion waited five seconds for a sheet that appears *after* AppKit tears down a **nested** submenu — two animations in series with a run loop handover between them, and the only wait in that file not aimed at an element already being drawn. Fifteen seconds now, at that one site. A sheet that never appears still fails, with the same message.

## The shards

| Shard | Classes | Tests |
|---|---|--:|
| core window, journeys, spec import | `MimicUITests`, `JourneyUITests`, `SpecImportUITests`, `ControlPlaneIsolationTests` | 51 |
| workspace shell, welcome, request log | `WorkspaceShellUITests`, `WelcomeProjectUITests`, `RequestLogUITests` | 53 |
| endpoint editor, alerts, journey editor | `EndpointEditorUITests`, `ErrorAlertUITests`, `JourneyEditorUITests` | 54 |

A count-spread of **2** is reachable (52/52/54) and deliberately not taken: both arrangements pair the workspace shell with the endpoint editor, leaving neither shard with a name that says what it covers. A shard name is the first thing you read when one goes red.

## Why sharding, and not `-parallel-testing-enabled`

Two independent reasons, both learned in #57:

- Every test shares one store and one defaults domain — `UITestSupport.databaseURL` is the fixed `mimic-uitests.sqlite`, `MIMIC_DEFAULTS_SUITE` is fixed, and `resetApp` deletes that store on every app launch. Two workers on one machine delete each other's state mid-test, and it presents as flakiness.
- This is a macOS app, not a simulator. Parallel workers share one window server and one frontmost application, and these suites lean on `typeText`, `typeKey` and ⌘-click. There is no simulator-clone equivalent.

A runner per shard removes both. Ports needed no work: the suites already use non-overlapping ranges and `MIMIC_CONTROL_FILE` is keyed by runner pid.

## Build-once-test-many: considered, rejected on arithmetic

Shards run **concurrently**, so the build was never on the critical path more than once. Hoisting it into a serial job *ahead of* every shard, plus a tar, an upload and three downloads, is a wash at best. What it genuinely saves is runner minutes — free on a public repository. The risk is the tiebreak rather than the case: a macOS `.app` through `upload-artifact` loses symlinks and permissions unless tarred, and a signature that does not survive presents as a broken *suite*, not a broken artifact.

## A new gate, because sharding invents a new way to be wrong

**A class no shard names never runs, and every shard is green.** Add `SettingsUITests.swift` tomorrow, write twenty tests, push, and green checks report the window covered. `xcodebuild` cannot notice — each shard got the classes it asked for. The workflow cannot notice — the workflow is what is wrong.

This repo has met that shape before: a `buildableFolders` line naming `Tests/JourneyFeatureTests` with no directory behind it, tolerated silently while the manifest read as though the journey UI had tests.

`Scripts/check_ui_shards.py` reads the `-only-testing:` flags out of the workflow and the classes out of the tree, and fails three ways: a class **no** shard runs, a class **two** shards run, and a shard naming a class that **does not exist** — the last being what a rename leaves behind, which `xcodebuild` reports as "no tests to run" and exits 0 for. Its `--self-test` drives every verdict over fixtures invented in the file, never read off disk and never produced by the functions under test.

Shard-count agnostic by construction, which the four→three rebalance confirmed rather than assumed: it reported "158 tests across 3" with no logic change. Negative control re-run after the rebalance.

## Also

- `record-coverage` declares `needs: macos-checks`. Coverage is measured before XCUITest starts, so the `always()` that kept a UI flake from suppressing the README update is no longer carrying that job — the dependency graph says it instead.
- `ui-suite` fails on `skipped` as well as `failure`, so a matrix that never ran cannot pass as green.
- The setup steps every macOS job needs are a composite action rather than four pasted copies.
- `Scripts/print_test_failures.sh` extracts the xcresult walker, shared by both job kinds.

## Verification

Green on CI three times: #89 (four shards), #90 and #92 (three). Between them the composite action, the shard gate running in CI, `-resultBundlePath` alongside `-retry-tests-on-failure`, `record-coverage` skipping correctly on a PR with its rewired dependency, the roll-up, and the concurrency budget have all been exercised.

Locally: both YAML files parse, all gates pass including three `--self-test`s, `actionlint`/`shellcheck`/`yamllint` clean against baseline (one fewer finding than HEAD), `bash -n` on every shell touched.