### PR TITLE
Shrink the README, and publish the coverage badges somewhere the branch rules allow

### DIFF
--- a/.agents/skills/mimic-build-and-test/SKILL.md
+++ b/.agents/skills/mimic-build-and-test/SKILL.md
@@ -23,8 +23,9 @@ at generation time, not written by anyone here.
 This section used to say the per-module schemes "build the frameworks but do not bundle their test
 targets", and that is why `Mimic-Workspace` was presented as the only way to run a unit suite. It
 cannot be right: [`Scripts/run_full_test_suite.sh`](../../../Scripts/run_full_test_suite.sh) — the
-only writer the README's coverage section has actually had, CI's `record-coverage` job being blocked
-by branch protection ([`references/ci.md`](references/ci.md)) — runs
+only writer the README's generated coverage block has, by design; CI publishes the two badges to an
+orphan branch instead and touches the README not at all
+([`references/ci.md`](references/ci.md)) — runs
 `xcodebuild -scheme Domain test` and six more against exactly
 those schemes, and `Scripts/update_readme_coverage.py` then reads the `Domain.xcresult`,
 `ControlPlane.xcresult` … bundles they leave behind. A scheme with nothing testable in it fails

--- a/.agents/skills/mimic-build-and-test/SKILL.md
+++ b/.agents/skills/mimic-build-and-test/SKILL.md
@@ -22,8 +22,9 @@ at generation time, not written by anyone here.
 
 This section used to say the per-module schemes "build the frameworks but do not bundle their test
 targets", and that is why `Mimic-Workspace` was presented as the only way to run a unit suite. It
-cannot be right: [`Scripts/run_full_test_suite.sh`](../../../Scripts/run_full_test_suite.sh) — one of
-the two producers of the README's coverage numbers, the other being CI's `record-coverage` job — runs
+cannot be right: [`Scripts/run_full_test_suite.sh`](../../../Scripts/run_full_test_suite.sh) — the
+only writer the README's coverage section has actually had, CI's `record-coverage` job being blocked
+by branch protection ([`references/ci.md`](references/ci.md)) — runs
 `xcodebuild -scheme Domain test` and six more against exactly
 those schemes, and `Scripts/update_readme_coverage.py` then reads the `Domain.xcresult`,
 `ControlPlane.xcresult` … bundles they leave behind. A scheme with nothing testable in it fails

--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -10,16 +10,16 @@ hosted runners on public repositories, macOS included.
 | `macos-checks` | `macos-26` | `tuist generate`, the Debug build, the app-level suites **with the coverage measurement**, the CLI end-to-end check (non-gating), the Release gate and its warning inventory |
 | `macos-ui` (×3) | `macos-26` | The XCUITest suite, sharded across three runners by test class |
 | `ui-suite` | `ubuntu-latest` | Rolls the three shard results into one status check |
-| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: writes the measured coverage into README.md — and has never been allowed to push it, see below |
+| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: publishes the measured coverage as two shields.io endpoint payloads on the orphan `badges` branch, which README.md's badges read |
 
 `record-coverage` is the only job holding `contents: write`, and it holds it precisely so that the
 jobs compiling code out of a pull request do not — see the comments above it and above `Emit coverage
 figures`. It needs `macos-checks` and **not** the UI shards, because coverage is measured in that job
 and because this repository's UI suite is documented as ending red on a test that passed on its
-retry; making the recording wait on the shards would mean the README updates only on runs where a
+retry; making the publishing wait on the shards would mean the badges update only on runs where a
 flake happened not to fire.
 
-## Coverage: measured every run, recorded when the branch lets it
+## Coverage: measured every run, published to a branch of its own
 
 The measurement lives inside `macos-checks` rather than in a job of its own. Its `Test (unit suites)`
 step runs the `Mimic-Workspace` scheme with `-enableCodeCoverage YES` and writes the result bundle to
@@ -32,26 +32,36 @@ Two things sit outside the figures, both structurally. **XCUITest**, because the
 measuring is the one passing `-skip-testing:MimicUITests` — the UI suite runs in three jobs beside
 it. And **everything the Linux job runs**, because gathering coverage needs the Xcode toolchain.
 
-`record-coverage` then rewrites README.md's two badges and the block between its
-`coverage:generated` markers with `Scripts/update_readme_coverage.py`. Four things about that job are
-deliberate, and each is the answer to a way this normally goes wrong:
+### The two figures go to two different places, on purpose
 
-- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS
-  jobs compile and run code out of a pull request; a write token there would widen the blast radius
-  of anything going wrong in one to "can push to `main`". The recording job runs one Python script
-  over one Markdown file.
-- **A few hundred bytes cross between the two, not the bundle.** The macOS job emits the figures as
-  JSON (`--emit-json`) and hands them on as a job output; the `.xcresult` is hundreds of megabytes
-  and stays on the runner that made it. That hand-off is also what lets the recording run on Linux.
-- **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
-  coverage figures, so an unchanged measurement leaves the file byte-identical and `git diff --quiet`
-  finds nothing to commit — otherwise `main` would collect one commit per push forever. The commit
-  that *is* made carries `[skip ci]`, or it would trigger the workflow that wrote it.
-- **It records; it never gates.** The step is `continue-on-error`. A rejected push warns and prints
-  the diff it wanted to make into the job summary; it never reddens a commit whose tests passed.
+**The badges at the top of README.md are CI's.** `record-coverage` turns the figures into two
+shields.io *endpoint* payloads with `Scripts/update_readme_coverage.py --from-json --emit-badges`,
+and force-pushes them to the `badges` branch:
 
-**No push has ever landed, and the job is not what is wrong.** It has run and succeeded on every push
-to `main` since it was added, and every push it made was refused:
+```
+badges/app-coverage.json      {"schemaVersion": 1, "label": "Mimic.app coverage",
+                               "message": "72.41%", "color": "red"}
+badges/module-coverage.json   {"schemaVersion": 1, "label": "modules at or above 95%",
+                               "message": "5/8", "color": "red"}
+```
+
+Four keys, nothing else — no timestamp, no run URL. The colour comes from the same ladder the badges
+have always used (95% brightgreen, 90% green, 80% yellow, below that red), and the module badge is
+coloured by the *proportion* clearing the bar, so `5/8` is 62.5% and red while `8/8` is bright green.
+
+The README links each through `https://img.shields.io/endpoint?url=…`, percent-encoded, at
+`raw.githubusercontent.com/srpadrono/mimic/badges/<file>`. **Nothing in the tracked tree moves when
+the badges do**, which is the whole point.
+
+**The detailed per-target block between the `coverage:generated` markers is a local run's.**
+`./Scripts/run_full_test_suite.sh` on a Mac writes it and is its only writer — by design now, not by
+accident: `--from-json` refuses to run without `--emit-badges`, so no CI path can reach the README at
+all. Expect the block to be older than the badges; the block's own provenance line says so.
+
+### Why an orphan branch and not a bypass on `main`
+
+The job used to rewrite README.md and push it to `main`. **Every push it ever made was refused**,
+across six merges, while the job itself went green:
 
 ```
 remote: error: GH006: Protected branch update failed for refs/heads/main.
@@ -60,21 +70,59 @@ remote: - Changes must be made through a pull request.
 ##[warning]Could not push the coverage update to main — the diff is in the job summary.
 ```
 
-`main` requires changes to arrive through a pull request and the Actions bot is not exempt, so the
-retry-after-rebase path does not help either — this is a rule, not a lost race. That is why both
-coverage badges still read `not measured` and the generated block in README.md is empty, while the
-figures have been in every macOS job summary the whole time. The fix is a repository setting — let
-the bot bypass the rule for that path — not a change to the workflow, which behaves exactly as
-designed. Do not "fix" it in YAML, and do not let the README claim the recording happens.
+That is a rule, not a lost race: `main` takes changes only through a pull request and the Actions bot
+is not exempt, so the retry-after-rebase the old step did could never have helped. Two ways out
+existed — let the bot bypass the rule, or put the figures where the rule does not apply. **The owner
+declined to weaken `main`'s protection for a badge**, so the badges moved.
+
+`badges` is an **orphan** branch: created by the job if absent, no history from `main`, no source in
+it, nothing that could need reviewing. Each run builds one parentless commit holding exactly the two
+JSON files and force-pushes it, so the branch never accumulates history and stays a few hundred bytes
+for the life of the repository. The recipe is worth reading once, because one step in it surprises
+people: `git checkout --orphan` starts the branch with no parent but **keeps `main`'s files staged**,
+so `git rm -r --cached .` clears the index (touching nothing on disk) before the two payloads are
+added. The payloads are written to a `mktemp -d` outside the checkout, both because `.artifacts/` is
+gitignored and `git add` would refuse them, and because they have to survive that index clear.
+
+The branch name is written down **once**, in `Scripts/update_readme_coverage.py`, beside the URL
+builder that produces what README.md must link. The workflow asks for it
+(`--print-badge-branch`) rather than repeating it, and `--self-test` pins the two URLs to literals
+so moving the branch fails the gate instead of silently 404ing both badges.
+
+### What is deliberate about the job
+
+- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS
+  jobs compile and run code out of a pull request; a write token there would widen the blast radius
+  of anything going wrong in one to "can push". This job runs one stdlib Python script and some git —
+  no build, no test, no repository code.
+- **A few hundred bytes cross between the two, not the bundle.** The macOS job emits the figures as
+  JSON (`--emit-json`) and hands them on as a job output; the `.xcresult` is hundreds of megabytes
+  and stays on the runner that made it. That hand-off is also what lets the publishing run on Linux.
+- **Nothing generated carries a timestamp, run number or run URL.** The branch is force-pushed to one
+  commit regardless, so this no longer protects CI from anything — but the README block is still a
+  pure function of the figures, because a *human* commits that one and an unchanged local measurement
+  must leave the file byte-identical rather than dirtying the tree.
+- **No `[skip ci]`, and its absence is the point.** The marker was load-bearing when this pushed to
+  `main`: without it the commit triggered the workflow that wrote it. The `push:` trigger names
+  `branches: [main]`, so a push to `badges` matches nothing. Restore a push to `main` and the marker
+  has to come back with it.
+- **It publishes; it never gates.** The step is `continue-on-error`, and it writes both payloads into
+  the job summary *before* it touches git — so a failed publish leaves the figures on the run page
+  and the badges showing whatever was last published. It never reddens a commit whose tests passed.
+
+**shields.io caches an endpoint response for a few minutes.** A badge that still shows the previous
+figure right after a merge is the cache, not a failed publish; check the raw URL before investigating
+the job.
 
 **No coverage floor is enforced, deliberately.** A threshold picked before anybody has seen the
 number is either so low it never fires or red on the run that introduces it. Measuring first, then
 setting the floor against a baseline, is the order.
 
-The half of `update_readme_coverage.py` that needs no Mac — the JSON round trip, both rewriters and
-the refusals — is covered by `python3 Scripts/update_readme_coverage.py --self-test`, which the Linux
-job runs beside the other checkers. It had no automated test of any kind before it started writing to
-`main`.
+The half of `update_readme_coverage.py` that needs no Mac — the badge URLs, the badge payloads, the
+colour ladder, the JSON round trip, the block rewriter and every refusal — is covered by
+`python3 Scripts/update_readme_coverage.py --self-test`, which the Linux job runs beside the other
+checkers. Every expected value in it is written out longhand; nothing asks a function under test what
+the right answer is.
 
 ## Why the macOS work is split the way it is
 

--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -10,7 +10,7 @@ hosted runners on public repositories, macOS included.
 | `macos-checks` | `macos-26` | `tuist generate`, the Debug build, the app-level suites **with the coverage measurement**, the CLI end-to-end check (non-gating), the Release gate and its warning inventory |
 | `macos-ui` (×3) | `macos-26` | The XCUITest suite, sharded across three runners by test class |
 | `ui-suite` | `ubuntu-latest` | Rolls the three shard results into one status check |
-| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: writes the measured coverage into README.md |
+| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: writes the measured coverage into README.md — and has never been allowed to push it, see below |
 
 `record-coverage` is the only job holding `contents: write`, and it holds it precisely so that the
 jobs compiling code out of a pull request do not — see the comments above it and above `Emit coverage
@@ -18,6 +18,63 @@ figures`. It needs `macos-checks` and **not** the UI shards, because coverage is
 and because this repository's UI suite is documented as ending red on a test that passed on its
 retry; making the recording wait on the shards would mean the README updates only on runs where a
 flake happened not to fire.
+
+## Coverage: measured every run, recorded when the branch lets it
+
+The measurement lives inside `macos-checks` rather than in a job of its own. Its `Test (unit suites)`
+step runs the `Mimic-Workspace` scheme with `-enableCodeCoverage YES` and writes the result bundle to
+a named path; the `Coverage report` step reads that bundle with `xcrun xccov` and prints a per-target
+table into the **job summary**, so "how much of this is actually exercised" is a link away rather
+than a script somebody has to remember to run. On a red run the bundle is uploaded as the
+`xcresult-unit` artifact, which is where per-file detail lives.
+
+Two things sit outside the figures, both structurally. **XCUITest**, because the step doing the
+measuring is the one passing `-skip-testing:MimicUITests` — the UI suite runs in three jobs beside
+it. And **everything the Linux job runs**, because gathering coverage needs the Xcode toolchain.
+
+`record-coverage` then rewrites README.md's two badges and the block between its
+`coverage:generated` markers with `Scripts/update_readme_coverage.py`. Four things about that job are
+deliberate, and each is the answer to a way this normally goes wrong:
+
+- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS
+  jobs compile and run code out of a pull request; a write token there would widen the blast radius
+  of anything going wrong in one to "can push to `main`". The recording job runs one Python script
+  over one Markdown file.
+- **A few hundred bytes cross between the two, not the bundle.** The macOS job emits the figures as
+  JSON (`--emit-json`) and hands them on as a job output; the `.xcresult` is hundreds of megabytes
+  and stays on the runner that made it. That hand-off is also what lets the recording run on Linux.
+- **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
+  coverage figures, so an unchanged measurement leaves the file byte-identical and `git diff --quiet`
+  finds nothing to commit — otherwise `main` would collect one commit per push forever. The commit
+  that *is* made carries `[skip ci]`, or it would trigger the workflow that wrote it.
+- **It records; it never gates.** The step is `continue-on-error`. A rejected push warns and prints
+  the diff it wanted to make into the job summary; it never reddens a commit whose tests passed.
+
+**No push has ever landed, and the job is not what is wrong.** It has run and succeeded on every push
+to `main` since it was added, and every push it made was refused:
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through a pull request.
+! [remote rejected] HEAD -> main (protected branch hook declined)
+##[warning]Could not push the coverage update to main — the diff is in the job summary.
+```
+
+`main` requires changes to arrive through a pull request and the Actions bot is not exempt, so the
+retry-after-rebase path does not help either — this is a rule, not a lost race. That is why both
+coverage badges still read `not measured` and the generated block in README.md is empty, while the
+figures have been in every macOS job summary the whole time. The fix is a repository setting — let
+the bot bypass the rule for that path — not a change to the workflow, which behaves exactly as
+designed. Do not "fix" it in YAML, and do not let the README claim the recording happens.
+
+**No coverage floor is enforced, deliberately.** A threshold picked before anybody has seen the
+number is either so low it never fires or red on the run that introduces it. Measuring first, then
+setting the floor against a baseline, is the order.
+
+The half of `update_readme_coverage.py` that needs no Mac — the JSON round trip, both rewriters and
+the refusals — is covered by `python3 Scripts/update_readme_coverage.py --self-test`, which the Linux
+job runs beside the other checkers. It had no automated test of any kind before it started writing to
+`main`.
 
 ## Why the macOS work is split the way it is
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,17 +351,22 @@ jobs:
       - name: Skill layout
         run: python3 Scripts/check_skills.py
 
-      # `Scripts/update_readme_coverage.py` is what writes the README's coverage badges and table,
-      # and until this line it had no automated check of any kind. Half of it needs `xcrun xccov`
-      # and a real `.xcresult`, so only the macOS job can exercise that half — but the half that
-      # matters most to a reader, the one that rewrites README.md, is pure string work and runs
-      # anywhere. `--self-test` drives it against a fixture README: both badges, the generated
-      # block, the JSON round trip, prose outside the markers surviving, and the three refusals
-      # (a partial target list, a malformed payload, a README with no badges).
+      # `Scripts/update_readme_coverage.py` builds the badge payloads `record-coverage` publishes
+      # and rewrites the README's generated table, and until this line it had no automated check of
+      # any kind. Half of it needs `xcrun xccov` and a real `.xcresult`, so only the macOS job can
+      # exercise that half — everything else is pure string work and runs anywhere. `--self-test`
+      # covers it against fixtures written out longhand in the script: the two shields.io endpoint
+      # URLs, the two payload documents whole, the colour ladder at every boundary, the JSON round
+      # trip, the generated block, prose outside the markers surviving, and the refusals (a partial
+      # target list, a malformed payload, a payload with no modules, a README with no badges, a
+      # README still carrying the old static ones).
       #
-      # It also pins the property the `record-coverage` job depends on — that rewriting with
-      # unchanged figures produces byte-identical output — because the day that stops being true is
-      # the day `main` starts collecting a commit per push.
+      # Two properties it pins that live outside the script. The badge URLs are literals here *and*
+      # in README.md, so moving the `badges` branch fails this step instead of turning both badges
+      # into shields.io's "invalid" placeholder. And rewriting with unchanged figures still has to
+      # produce byte-identical output — the recording job no longer needs that, since it force-pushes
+      # one commit either way, but a human commits the README block and a full-suite run must not
+      # dirty the tree over an unchanged measurement.
       #
       # Here rather than on macOS for the same reason as the house rules above: it needs nothing a
       # Mac has, and it is a tenth of a second.
@@ -492,9 +497,11 @@ jobs:
       #     exists is either so low it never fires or so high it is red on arrival, and both teach
       #     people to ignore it. The floor is the next step, once a few runs have published numbers
       #     and somebody can pick one that means something.
-      #   - **No README rewrite.** The two badges are still written only by
-      #     `Scripts/run_full_test_suite.sh` on a Mac. This workflow runs with `contents: read` on
-      #     pull requests from forks; a job that edited tracked files would have nowhere to put them.
+      #   - **No writing of any kind.** This step measures and hands the numbers on. The badges are
+      #     published by `record-coverage` at the bottom of this file, to a branch that carries
+      #     nothing else; the README's detailed block is written only by
+      #     `Scripts/run_full_test_suite.sh` on a Mac. This job runs with `contents: read` on pull
+      #     requests from forks, and has no business holding anything wider.
       - name: Test (unit suites)
         run: |
           rm -rf .artifacts/coverage
@@ -535,7 +542,7 @@ jobs:
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       # (c): the same figures again, as a few hundred bytes of JSON handed to the `record-coverage`
-      # job at the bottom of this file, which writes them into README.md.
+      # job at the bottom of this file, which turns them into the two badge payloads.
       #
       # A **job output**, not an artifact, and not three more lines on that job. Two constraints
       # meet here. `contents: write` must not live on this job — it is the one that compiles and
@@ -555,9 +562,9 @@ jobs:
       # into a pass.
       #
       # That refusal is safe to leave loud-but-not-fatal because its failure announces itself: no
-      # figures means no recording, and the badges in the README go on reading `not measured` until
-      # somebody looks. A silent wrong number is the outcome worth engineering against; a visibly
-      # absent one is not.
+      # figures means nothing is published, and the badges go on showing the figures from the last
+      # push that did measure — visibly stale rather than quietly wrong. A silent wrong number is the
+      # outcome worth engineering against; an old one is not.
       #
       # Only on a push to `main`: on a pull request there is nowhere to record the result, and the
       # numbers describe the merged commit anyway.
@@ -1021,16 +1028,52 @@ jobs:
               ;;
           esac
 
-  # The one job in this workflow that writes to the repository. It records the coverage
-  # `macos-checks` measured into README.md's two badges and the block between its
-  # `coverage:generated` markers — the thing both badges spent this repository's whole history saying
-  # `not measured` for while the number was being computed on every run and thrown away with the
-  # runner.
+  # The one job in this workflow that writes to the repository. It publishes the coverage
+  # `macos-checks` measured as the two shields.io endpoint payloads README.md's badges read — the
+  # thing both badges spent this repository's whole history saying `not measured` for while the
+  # number was being computed on every run and thrown away with the runner.
+  #
+  # ## Why an orphan branch and not a commit on `main`
+  #
+  # This job used to rewrite README.md and push it to `main`. **Every push it ever made was refused**,
+  # for six merges, while the job itself went green:
+  #
+  #     remote: error: GH006: Protected branch update failed for refs/heads/main.
+  #     remote: - Changes must be made through a pull request.
+  #
+  # That is a rule rather than a lost race — `main` takes changes only through a pull request, the
+  # Actions bot is not exempt, and the retry-after-rebase the old step did could never have helped.
+  # The two ways out were to let the bot bypass the rule, which weakens `main`'s protection for a
+  # badge, or to put the figures somewhere the rule does not apply. The owner chose the second.
+  #
+  # So the payloads go to **`badges`, an orphan branch**: no history from `main`, no source, nothing
+  # to review, a few hundred bytes forever. `Scripts/update_readme_coverage.py --print-badge-branch`
+  # is what names it, so the branch is written down once — in the same file that builds the badge
+  # URLs README.md has to carry — instead of once here and once in Markdown.
+  #
+  # Three properties the old path needed, and where each of them stands now:
+  #
+  #   - **`[skip ci]` on the commit.** It was load-bearing: a commit on `main` triggers the workflow
+  #     that wrote it, and without the marker this job fed itself forever. The hazard is *gone*
+  #     rather than handled — this workflow's `push:` trigger names `branches: [main]`, and nothing
+  #     pushed to `badges` matches it. Restore a push to `main` here and the marker has to come back
+  #     with it.
+  #   - **"Commit only when the numbers moved."** The old step ran `git diff --quiet` first, because
+  #     `main` would otherwise collect one commit per push forever — which is also why nothing this
+  #     script generates carries a timestamp, a run number or a run URL. The branch below is
+  #     force-pushed to a single parentless commit every time, so it cannot accumulate history
+  #     whatever the payload says, and the check is dead here. **The no-timestamp rule is not**: the
+  #     README's detailed block is still a pure function of the figures, because a human commits that
+  #     one and a full-suite run must not dirty the tree on an unchanged measurement.
+  #   - **It records; it never gates.** Unchanged, and the reason is unchanged: a coverage
+  #     measurement is not a verdict on a commit. The step is `continue-on-error`, and it writes the
+  #     payloads into the job summary *before* it tries to publish them, so a failed push leaves the
+  #     figures visible on the run page rather than lost with the runner.
   #
   # Why this is a separate job on Linux rather than three more lines on the macOS one is argued at
   # `Emit coverage figures` above: `contents: write` must not sit on the job that compiles and runs
-  # code out of a pull request. What runs here is one stdlib Python script over one Markdown file.
-  # No build, no test, no repository code executes.
+  # code out of a pull request. What runs here is one stdlib Python script and some git. No build,
+  # no test, no repository code executes.
   #
   # **`needs: macos-checks`, not the UI shards, and that is now structural rather than a workaround.**
   # It used to say `needs: macos` with `always()`, because coverage is measured two steps before
@@ -1043,7 +1086,7 @@ jobs:
   # output empty, which the first step below reports and stops on, rather than skipping this job with
   # no explanation.
   record-coverage:
-    name: Record coverage in README
+    name: Publish coverage badges
     needs: macos-checks
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
@@ -1051,14 +1094,13 @@ jobs:
       contents: write
 
     steps:
+      # The pushed SHA at depth 1, which is the default and is all this job needs. It used to ask
+      # for `ref: main` and `fetch-depth: 0`, because it committed to `main` and the push at the end
+      # might have had to rebase onto a tip that moved while the macOS job ran. Neither applies to a
+      # parentless commit on a branch nothing else writes to, and taking the pushed SHA is the more
+      # honest of the two anyway: the payloads are produced by the version of
+      # `Scripts/update_readme_coverage.py` that belongs to the commit being measured.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # `main` rather than the pushed SHA, because the number goes where a reader will look for
-          # it. `fetch-depth: 0` because the push at the end may have to rebase onto a tip that
-          # moved while the macOS job was still running, and a depth-1 clone has nothing to rebase
-          # onto.
-          ref: main
-          fetch-depth: 0
 
       # The job output goes through `env:` rather than straight into `run:`. A `${{ }}` interpolated
       # into a shell line is substituted before the shell ever sees it, so its content is parsed as
@@ -1079,58 +1121,68 @@ jobs:
           printf '%s\n' "$COVERAGE_JSON" > .artifacts/coverage/coverage.json
           echo "state=ready" >> "$GITHUB_OUTPUT"
 
-      # `main` is a protected branch. Whether these rules let this token push is a repository
-      # setting rather than anything a commit can fix, so a rejection must not redden a commit whose
-      # tests all passed: the step warns, and puts the diff it wanted to make into the job summary
-      # where somebody can apply it by hand. The number is never lost, at worst it is not committed.
-      - name: Record it in README.md
+      # Two shields.io endpoint payloads, force-pushed as a single parentless commit onto the
+      # `badges` branch. See this job's header for why they do not go into README.md on `main`.
+      #
+      # `continue-on-error`, and the figures reach `$GITHUB_STEP_SUMMARY` before any git runs, so
+      # every way this can fail — the payload malformed, the branch protected after all, the token
+      # refused — leaves the numbers on the run page and the badges showing whatever was last
+      # published. A coverage measurement never reddens a commit whose tests passed.
+      - name: Publish the badge payloads
         if: steps.figures.outputs.state == 'ready'
         continue-on-error: true
         run: |
           set -euo pipefail
 
+          # The script owns the branch name, beside the URLs it builds for README.md. Asking it
+          # keeps this file from being a second place the name is written down.
+          branch="$(python3 Scripts/update_readme_coverage.py --print-badge-branch)"
+
+          # Outside the checkout, because `.artifacts/` is gitignored and `git add` would refuse
+          # these paths, and because the orphan branch below is built by clearing the index — the
+          # payloads have to survive that.
+          badges="$(mktemp -d)"
           python3 Scripts/update_readme_coverage.py \
             --from-json .artifacts/coverage/coverage.json \
-            --readme README.md
+            --emit-badges "$badges"
 
-          # The generated block is a pure function of the figures — no timestamp, no run URL — so an
-          # unchanged measurement leaves the file byte-identical and there is nothing to commit.
-          # Without that property `main` would grow one commit per push forever.
-          if git diff --quiet -- README.md; then
-            echo "README.md already records these figures — nothing to commit."
-            exit 0
-          fi
+          {
+            echo '### Coverage badge payloads'
+            echo
+            echo "Measured on this commit and force-pushed to the \`$branch\` branch, where"
+            echo 'shields.io reads them for the two badges at the top of README.md. If the push'
+            echo 'below failed, the badges still show the last figures that were published and'
+            echo 'these are the ones they would have shown.'
+            for payload in "$badges"/*.json; do
+              echo
+              echo "\`$(basename "$payload")\`:"
+              echo
+              echo '```json'
+              cat "$payload"
+              echo '```'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add README.md
-          # `[skip ci]` is load-bearing: without it this commit triggers the workflow that wrote it.
-          git commit -m 'docs: record measured coverage in the README [skip ci]'
 
-          if git push origin HEAD:main; then
-            echo "Recorded."
-            exit 0
-          fi
+          # `--orphan` starts a branch with no parent commit, so none of `main`'s history comes with
+          # it. It does keep `main`'s files staged, which is the one surprise in this recipe:
+          # `git rm --cached` clears the index without deleting anything from disk, leaving a commit
+          # that contains the two payloads and nothing else.
+          git checkout --quiet --orphan "$branch"
+          git rm -r --quiet --cached .
+          cp "$badges"/*.json .
+          git add app-coverage.json module-coverage.json
+          git commit --quiet -m 'chore: publish measured coverage as badge endpoints'
 
-          # A push can also simply lose a race — `main` moved while the macOS job was running. That
-          # is worth exactly one rebase before concluding the branch rules are what rejected it.
-          echo "Push rejected; rebasing onto main and trying once more."
-          if git pull --rebase origin main && git push origin HEAD:main; then
-            echo "Recorded after a rebase."
-            exit 0
-          fi
-
-          echo "::warning::Could not push the coverage update to main — the diff is in the job summary."
-          patch="$(git diff 'HEAD^' HEAD -- README.md || true)"
-          {
-            echo '### Coverage measured, but not recorded'
-            echo
-            echo 'The push to `main` was rejected. If branch protection is what refused it, either'
-            echo 'allow the Actions bot to bypass the rule for this path, or apply the diff below by'
-            echo 'hand. The figures themselves are in the macOS job'"'"'s summary and its job output.'
-            echo
-            echo '```diff'
-            printf '%s\n' "$patch"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 1
+          # `--force`, always. The branch must never accumulate history: each run replaces its one
+          # commit, the previous one becomes unreachable, and the branch stays a few hundred bytes
+          # for the life of the repository. It also creates the branch on the first run, so nothing
+          # has to exist beforehand.
+          #
+          # No `[skip ci]` on the commit above, and its absence is deliberate rather than an
+          # oversight. The marker was load-bearing when this pushed to `main`; the `push:` trigger at
+          # the top of this file names `branches: [main]`, so a push here cannot trigger anything.
+          git push --force origin "HEAD:refs/heads/$branch"
+          echo "Published to $branch."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,11 @@ xcodebuild -workspace Mimic.xcworkspace -scheme Mimic -configuration Release \
 `Project.swift` declares exactly one scheme, `Mimic`. Everything else you can pass to `-scheme` —
 `Mimic-Workspace` and one per module — is inferred by Tuist, and the inferred per-module schemes do
 carry their `<Module>Tests` target: `Scripts/run_full_test_suite.sh` runs `xcodebuild -scheme Domain
-test` and six more, and README's coverage section can be generated from the `.xcresult` bundles they
-produce. (CI measures the same thing on every run, from the one workspace-wide bundle its macOS job
-produces, and its `record-coverage` job tries to write that section on every push to `main` — but
-branch protection has rejected every one of those pushes, so a local run is still the only way the
-badges have ever moved. See the `mimic-build-and-test` skill,
+test` and six more, and README's generated coverage block is written from the `.xcresult` bundles
+they produce. (That local run is the block's only writer, deliberately. CI measures the same thing on
+every run, from the one workspace-wide bundle its macOS job produces, but what it publishes on a push
+to `main` is the two README *badges*, as shields.io endpoint payloads force-pushed to an orphan
+`badges` branch — it never edits a tracked file. See the `mimic-build-and-test` skill,
 [`references/ci.md`](.agents/skills/mimic-build-and-test/references/ci.md).) (This file used to claim
 the opposite about the schemes, which is why `Mimic-Workspace` was presented as the
 only way to run a unit suite. Prefer it because it covers everything in one pass, not because the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,12 @@ xcodebuild -workspace Mimic.xcworkspace -scheme Mimic -configuration Release \
 `Mimic-Workspace` and one per module — is inferred by Tuist, and the inferred per-module schemes do
 carry their `<Module>Tests` target: `Scripts/run_full_test_suite.sh` runs `xcodebuild -scheme Domain
 test` and six more, and README's coverage section can be generated from the `.xcresult` bundles they
-produce. (CI writes that same section on every push to `main`, from the one workspace-wide bundle
-its macOS job measures — so running the full suite locally is no longer the only way the badges
-ever move.) (This file used to claim the opposite, which is why `Mimic-Workspace` was presented as the
+produce. (CI measures the same thing on every run, from the one workspace-wide bundle its macOS job
+produces, and its `record-coverage` job tries to write that section on every push to `main` — but
+branch protection has rejected every one of those pushes, so a local run is still the only way the
+badges have ever moved. See the `mimic-build-and-test` skill,
+[`references/ci.md`](.agents/skills/mimic-build-and-test/references/ci.md).) (This file used to claim
+the opposite about the schemes, which is why `Mimic-Workspace` was presented as the
 only way to run a unit suite. Prefer it because it covers everything in one pass, not because the
 others cannot test.) `xcodebuild -workspace Mimic.xcworkspace -list` prints what was actually
 generated.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ failures, and watch live traffic. Then drive all of it from a script.
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
 [![Tests](https://img.shields.io/badge/tests-1145%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
-[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
+[![App Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
+[![Module Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json)](#coverage)
 
 [Install](#install) · [Quickstart](#quickstart) · [Journeys](#journeys) · [CLI](docs/CLI.md) · [Architecture](docs/ARCHITECTURE.md)
 
@@ -287,15 +287,13 @@ python3 Scripts/check_doc_counts.py    # recount every number above, and catch a
 
 ### Coverage
 
-**Coverage is measured on every CI run.** The macOS job runs the unit suites with
-`-enableCodeCoverage YES` and prints a per-target table into that job's summary — XCUITest and the
-Linux suites excepted. No floor is enforced against the figures, deliberately.
-
-**They are not recorded here yet.** The `record-coverage` job rewrites the two badges and the block
-below on every push to `main`, and branch protection has refused every push it has made, since
-changes to `main` must arrive through a pull request. Letting the Actions bot past that rule is a
-repository setting rather than anything the workflow can fix, so the job warns rather than reddening
-a commit whose tests passed — and the badges go on reading `not measured`.
+**Coverage is measured on every CI run**, by the macOS job running the unit suites with
+`-enableCodeCoverage YES` — XCUITest and the Linux suites excepted, and no floor enforced against
+the figures. **The two badges above are live**: every push to `main` publishes them to an orphan
+`badges` branch as shields.io endpoint payloads, so nothing in the tree changes when they move. The
+detailed per-target block below is the other half, and it is deliberately local-only —
+`./Scripts/run_full_test_suite.sh` on a Mac is its only writer, so it is as fresh as the last full
+run somebody did by hand.
 
 <!-- coverage:generated:start -->
 <!-- coverage:generated:end -->

--- a/README.md
+++ b/README.md
@@ -261,9 +261,8 @@ every command through the shipped host. See [AGENTS.md](AGENTS.md#one-host) and
 
 ## Testing
 
-1145 tests, counted as `@Test` and `func test` declarations — a parameterized case runs more than
-once and is still one declaration. Swift Testing for units and integration, XCTest with page objects
-for UI.
+1145 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
+and is still one declaration. Swift Testing for units, XCTest with page objects for UI.
 
 | Suite | Count | Where it runs |
 |-------|-------|---------------|
@@ -275,126 +274,39 @@ for UI.
 The portable 634 break down as Domain 232, SpecImport 128, MimicCLICore 113, MockServerEngine 70,
 Persistence 69, ControlPlane 22. The app's 295 are the six folders `MimicTests` builds —
 `WorkspaceFeatureTests` 109, `MimicTests` 142, `JourneyFeatureTests` 14, `ImportFeatureTests` 15,
-`ProjectFeatureTests` 6, `EndpointFeatureTests` 9.
-
-`JourneyFeatureTests` is new, and it closes something this section used to state as a decision:
-`Sources/AppFeatures/JourneyFeature` was described here as deliberately having no suite of its own
-because `MimicTests` covered the journey UI. It was the one feature folder with no tests at all.
-`Project.swift` now lists `Tests/JourneyFeatureTests` among the folders the `MimicTests` target
-builds, and the directory exists behind it.
-
-Only the SwiftUI layer needs a Mac. The domain rules, mock engine, persistence, control plane, spec
-import and CLI are plain Swift, so [`Package.swift`](Package.swift) builds them anywhere while
-[`Project.swift`](Project.swift) (Tuist) builds the app. Both manifests declare those modules from
-the *same* directories, so they cannot drift in what they compile — but they resolve their
-dependencies into two separate lockfiles, and that pair *can* drift, so CI checks the two agree
-before it builds anything.
+`ProjectFeatureTests` 6, `EndpointFeatureTests` 9 — hand counts, two of which have been wrong, which
+is what the last command below is for. Only the SwiftUI layer needs a Mac; the rest is plain Swift,
+which is why [`Package.swift`](Package.swift) builds most of this anywhere.
 
 ```bash
-swift test                    # the portable 634, no Xcode needed
-./Scripts/ci.sh               # full local gate: build, all suites + coverage, Release, UI tests
+swift test                             # the portable 634, no Xcode needed
+./Scripts/ci.sh                        # the full local gate: build, suites, Release, UI, CLI e2e
+./Scripts/run_full_test_suite.sh       # macOS + Xcode; also rewrites the coverage section below
+python3 Scripts/check_doc_counts.py    # recount every number above, and catch a suite nobody runs
 ```
-
-The **Tests** badge at the top is hand-maintained, unlike the two coverage badges beside it, which
-`Scripts/update_readme_coverage.py` rewrites and which make the script fail loudly if the README has
-lost them. That asymmetry is why the counts above keep drifting: the table has twice claimed a
-figure the tree did not support — 469 / 34 / 181 against an actual 487 / 49 / 173, then 173 for the
-app row while a new parity suite was landing 13 more in the same afternoon. A hand count is only ever
-true of the commit that wrote it. It no longer has to be recounted by eye —
-[`Scripts/check_doc_counts.py`](Scripts/check_doc_counts.py) recounts every folder and fails naming
-each number here that has drifted:
-
-```bash
-python3 Scripts/check_doc_counts.py    # also run by ./Scripts/ci.sh and by the Linux CI job
-```
-
-It exits 0 against this table today. It also fails on a suite folder that exists and appears in none
-of its groups, which is what a newly added suite looks like before anybody writes it in — and is how
-`JourneyFeatureTests` was caught, hours after being created.
 
 ### Coverage
 
-**Coverage is measured on every CI run, and the numbers are on the run page.** The macOS job's
-`Test (unit suites)` step runs the `Mimic-Workspace` scheme with `-enableCodeCoverage YES` and
-writes its result bundle to a named path; the `Coverage report` step reads that bundle with
-`xcrun xccov` and prints a per-target table into the **job summary**. So the answer to "how much of
-this is actually exercised" is a link away rather than a script somebody has to remember to run.
+**Coverage is measured on every CI run.** The macOS job runs the unit suites with
+`-enableCodeCoverage YES` and prints a per-target table into that job's summary — XCUITest and the
+Linux suites excepted. No floor is enforced against the figures, deliberately.
 
-Where to look: any run of [`.github/workflows/ci.yml`](.github/workflows/ci.yml), under the
-**Build, unit suites, Release, CLI e2e (macOS)** job's summary. Two things sit outside that
-measurement, both structurally: XCUITest, because the step doing the measuring is the one that skips
-it — the UI suite runs in three sharded jobs beside this one — and everything the Linux job runs,
-because gathering coverage needs the Xcode toolchain. On a red run the bundle is uploaded as the
-`xcresult-unit` artifact, which is where per-file detail lives.
-
-**The numbers are also recorded here, on every push to `main`.** They used to exist only in that job
-summary — computed on every run and thrown away with the runner — which is why both badges above
-spent this repository's entire history reading `not measured` while the measurement was already
-happening. The `record-coverage` job closes that: the macOS job hands its figures on as a job
-output, and that job rewrites the two badges and the block below with
-[`Scripts/update_readme_coverage.py`](Scripts/update_readme_coverage.py).
-
-Four things about it are deliberate, and each is the answer to a way this normally goes wrong:
-
-- **It is a separate job, and the only one in the workflow holding `contents: write`.** The macOS
-  jobs compile and run code out of a pull request; a write token there would widen the blast radius
-  of anything going wrong in one to "can push to `main`". The recording job runs one Python script
-  over one Markdown file.
-- **A few hundred bytes cross between them, not the bundle.** The `.xcresult` is hundreds of
-  megabytes and stays on the runner that made it.
-- **The generated block carries no timestamp, run number or run URL.** It is a pure function of the
-  coverage figures, so an unchanged measurement leaves the file byte-identical and there is nothing
-  to commit — otherwise `main` would collect one commit per push forever. The commit that is made
-  carries `[skip ci]`, or it would trigger the workflow that wrote it.
-- **It records; it never gates.** `main` is a protected branch, and whether its rules let the Actions
-  bot push is a repository setting rather than something a commit can fix. A rejected push warns and
-  prints the diff it wanted to make into the job summary — it never reddens a commit whose tests
-  passed.
-
-A Mac still writes the same section from a full local suite, out of the per-scheme bundles rather
-than the workspace-wide one, and the generated block says which of the two produced it:
-
-```bash
-./Scripts/ci.sh                     # the CI gate locally, and prints the same per-target table
-./Scripts/run_full_test_suite.sh    # macOS + Xcode; rewrites this section and the two badges
-```
-
-The half of that script needing no Mac — the rewriting, the JSON hand-off and the refusals — is
-covered by `python3 Scripts/update_readme_coverage.py --self-test`, which the Linux job runs beside
-the other checkers. It had no automated test of any kind before it started writing to `main`.
-
-**No coverage floor is enforced, deliberately.** A threshold picked before anybody has seen the
-number is either so low it never fires or red on the run that introduces it. Measuring first, then
-setting the floor against a baseline, is the order.
+**They are not recorded here yet.** The `record-coverage` job rewrites the two badges and the block
+below on every push to `main`, and branch protection has refused every push it has made, since
+changes to `main` must arrive through a pull request. Letting the Actions bot past that rule is a
+repository setting rather than anything the workflow can fix, so the job warns rather than reddening
+a commit whose tests passed — and the badges go on reading `not measured`.
 
 <!-- coverage:generated:start -->
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
-`main`, in seven jobs across five definitions, and finishes in about **30 minutes**. Linux builds
-`Package.swift`, runs the portable suites and every gate that needs no toolchain, in a couple of
-minutes. On macOS, `Build, unit suites, Release, CLI e2e` runs `tuist generate`, the Debug build, the
-app-level suites — measured, with the per-target coverage table printed into the job summary — the
-CLI end-to-end check and the Release gate, while **the XCUITest suite runs beside it in three shards
-on three runners**, rolled up into one `UI suite` status check. A short `record-coverage` job writes
-the coverage figures into this file on pushes to `main`.
-
-The suite is sharded across machines rather than parallelised on one because every UI test shares a
-store, a defaults domain, a window server and a frontmost application; three is the shard count
-because the non-UI job takes one macOS slot and **four is how many concurrent macOS jobs this
-repository has actually been given**. GitHub documents five, and the first sharded run asked for
-five: run #89 started four jobs together and left the fifth queued for 19m26 — the length of a whole
-shard — which turned a predicted 29-minute run into a measured 43-minute one. Three shards of 51, 53
-and 54 tests fit the observed cap with nothing waiting. That split is a hand-maintained list of test
-classes, so [`Scripts/check_ui_shards.py`](Scripts/check_ui_shards.py) fails the Linux job if any
-class is run by no shard or by two — a class nobody runs would otherwise leave every shard green. The
-workflow's own header argues all of it, including why each shard builds for itself instead of
-downloading one shared build. It used to be a single 96-minute job with XCUITest as four fifths of
-it.
-
-Both runners are free on a public repository. (This section used to say Actions could not start
-a job here at all — true while the repository was private and a billing block killed every run in
-about two seconds; making it public resolved it.)
+`main`, in seven jobs across five definitions, finishing in about **30 minutes**: Linux builds
+`Package.swift`, the portable suites and every gate needing no toolchain in a couple of minutes;
+macOS does `tuist generate`, the Debug build, the measured app suites, the CLI end-to-end check and
+the Release gate, with the XCUITest suite beside it in three shards on three runners. Both runners
+are free on a public repository. Why the work divides that way, and what each gate settles, is in
+[`ci.md`](.agents/skills/mimic-build-and-test/references/ci.md).
 
 ## Documentation
 

--- a/Scripts/run_full_test_suite.sh
+++ b/Scripts/run_full_test_suite.sh
@@ -59,4 +59,7 @@ python3 "$ROOT_DIR/Scripts/update_readme_coverage.py" \
 
 echo "Full suite passed."
 echo "Coverage results: $RESULTS_DIR"
-echo "README coverage section updated."
+# The block between the `coverage:generated` markers, and only that. The two badges at the top of
+# the README are published by CI to the `badges` branch and are deliberately left alone here — a
+# local run that rewrote them would pin a laptop's figures over the ones measured on `main`.
+echo "README coverage block updated (the badges are CI's, and were not touched)."

--- a/Scripts/update_readme_coverage.py
+++ b/Scripts/update_readme_coverage.py
@@ -1,36 +1,49 @@
 #!/usr/bin/env python3
 
-"""Reads line coverage out of `.xcresult` bundles. One reader, four callers.
+"""Reads line coverage out of `.xcresult` bundles. One reader, five callers.
+
+**The two figures land in two different places, written by two different people, and that split is
+the design rather than an accident.** The badges at the top of README.md are published by CI, from
+`main`, as shields.io *endpoint* payloads on an orphan `badges` branch — nothing in the tracked tree
+moves when they change. The detailed per-target table between README.md's `coverage:generated`
+markers is written **only** by a local full-suite run on a Mac; no CI path writes it, and no mode of
+this script writes it from anything but `--results-dir`.
 
 **`--results-dir`** is the mode `Scripts/run_full_test_suite.sh` uses: one bundle per scheme, on a
-Mac, after a full suite run. It rewrites README.md's two coverage badges and the block between the
-`coverage:generated` markers, in place.
+Mac, after a full suite run. It rewrites the block between the `coverage:generated` markers, in
+place, and **does not touch the badges** — it checks them instead, see `check_badges`.
 
 **`--result-bundle`** is the mode `.github/workflows/ci.yml` uses for the job summary: one bundle —
 the workspace-wide unit run — printed as Markdown on stdout. It reads the bundle and changes
-nothing, so it is safe on a pull request from a fork, where the token is read-only and a README
-rewrite could not be committed anyway.
+nothing, so it is safe on a pull request from a fork, where the token is read-only.
 
 **`--result-bundle --emit-json`** writes those same numbers to a small JSON file instead of printing
-them. It is what the macOS job hands to the job that records them, so a several-hundred-megabyte
+them. It is what the macOS job hands to the job that publishes them, so a several-hundred-megabyte
 `.xcresult` never has to leave the runner that produced it.
 
-**`--from-json --readme`** rewrites the README from that file. It needs neither Xcode nor a bundle,
-which is what lets the recording job run on Linux holding `contents: write` while the job that
-compiles code out of a pull request keeps a read-only token. It rewrites *only* the two badges and
-the generated block, so a README edited between the measurement and the recording keeps the rest of
-its changes.
+**`--from-json --emit-badges`** turns that file into the two shields.io endpoint payloads the
+`badges` branch carries. It needs neither Xcode nor a bundle, which is what lets the publishing job
+run on Linux holding `contents: write` while the job that compiles code out of a pull request keeps
+a read-only token.
 
-Every mode goes through `target_metrics`, so the numbers a reviewer reads in a job summary and the
-numbers written into the README come out of one piece of code rather than two that agree by hand.
+**`--print-badge-branch`** prints the branch name the workflow force-pushes those payloads to, so
+the branch is written down once — here, beside the URLs the README has to carry — rather than once
+in YAML and once in Markdown.
 
-**Nothing generated here carries a timestamp, a run number or a run URL, deliberately.** The block
-is a pure function of the coverage figures, so an unchanged measurement produces a byte-identical
-README and the recording job's `git diff --quiet` finds nothing to commit. Put a run URL in it and
-`main` grows a commit per push forever.
+Every mode goes through `target_metrics`, so the numbers a reviewer reads in a job summary, the
+numbers on the badges and the numbers in the README table come out of one piece of code rather than
+three that agree by hand.
 
-`--self-test` exercises the JSON round trip and both rewriters against a fixture README, so the half
-of this file that needs no Mac is checked on every Linux CI run.
+**Nothing generated here carries a timestamp, a run number or a run URL, deliberately.** Everything
+written is a pure function of the coverage figures. That property no longer has to hold for CI — the
+badge branch is force-pushed to a single commit every time, so it cannot accumulate history whatever
+the payload says — but it still has to hold for the README block, which a human commits: an
+unchanged local measurement must leave the file byte-identical, or every full-suite run leaves a
+dirty tree and a diff nobody wants to read.
+
+`--self-test` exercises the JSON round trip, the badge payloads, the block rewriter and the refusals
+against fixtures written out longhand in this file, so the half of it that needs no Mac is checked
+on every Linux CI run.
 
 Stdlib only, so the Linux CI container's `python3-minimal` and a Mac's system Python both run it.
 """
@@ -67,6 +80,50 @@ MODULE_TARGETS = [
 # per-scheme runs do — the test bundles themselves among them — and inventing a second ordering for
 # them would be one more list to keep in step with this one.
 SUMMARY_ORDER = [APP_TARGET[1]] + [xccov_name for _, xccov_name, _ in MODULE_TARGETS]
+
+
+# ---------------------------------------------------------------------------
+# The published badges.
+#
+# `main` is protected: changes to it must arrive through a pull request, and the Actions bot is not
+# exempt. Every push the recording job ever made to `main` was refused with GH006, for six merges,
+# while the job itself went green — so the badges read `not measured` for this repository's whole
+# history. The owner declined to weaken the rule for a badge, so the figures go somewhere the rule
+# does not apply: an **orphan branch carrying nothing but these two files**, force-pushed to a single
+# commit on every push to `main`, holding no source and therefore needing no review.
+#
+# The four names below are the whole contract between three files — this script writes the payloads,
+# `.github/workflows/ci.yml` pushes them (asking `--print-badge-branch` for the branch rather than
+# repeating it), and README.md links them. `check_badges` holds the README to them, so renaming a
+# payload here fails the next full-suite run rather than silently turning both badges into
+# shields.io's "invalid" placeholder.
+BADGE_REPO = "srpadrono/mimic"
+BADGE_BRANCH = "badges"
+APP_BADGE_FILE = "app-coverage.json"
+MODULE_BADGE_FILE = "module-coverage.json"
+
+# The labels the badges have always carried, kept verbatim so the two badges do not change wording
+# on the day they start carrying a number.
+APP_BADGE_LABEL = "Mimic.app coverage"
+MODULE_BADGE_LABEL = "modules at or above 95%"
+
+
+def raw_url(filename: str) -> str:
+    """Where shields.io fetches one payload from."""
+    return f"https://raw.githubusercontent.com/{BADGE_REPO}/{BADGE_BRANCH}/{filename}"
+
+
+def endpoint_badge_url(filename: str) -> str:
+    """The `img.shields.io/endpoint` URL README.md must carry for one payload.
+
+    The inner URL is percent-encoded by hand rather than with `urllib.parse.quote`, because this
+    file's one hard constraint is that it imports nothing outside what the Linux container's
+    `python3-minimal` ships. Only `:` and `/` need escaping in a raw.githubusercontent.com URL —
+    everything else in one is unreserved — and `%` is escaped first so the transformation stays
+    correct if a name ever contains one.
+    """
+    encoded = raw_url(filename).replace("%", "%25").replace(":", "%3A").replace("/", "%2F")
+    return f"https://img.shields.io/endpoint?url={encoded}"
 
 
 @dataclass(frozen=True)
@@ -195,7 +252,7 @@ def build_coverage_block(
     for target_name, metrics in module_metrics:
         lines.append(f"| `{target_name}` | `{format_percent(metrics.percent)}` | `{format_lines(metrics)}` |")
 
-    modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
+    at_or_above = modules_at_or_above_95(module_metrics)
     total_executable_lines = app_metrics.executable_lines + sum(metrics.executable_lines for _, metrics in module_metrics)
     lines.extend(
         [
@@ -203,7 +260,7 @@ def build_coverage_block(
             "Coverage notes:",
             "",
             f"- App coverage is currently `{format_percent(app_metrics.percent)}`.",
-            f"- Modules at or above `95%`: `{modules_at_or_above_95}/{len(module_metrics)}`.",
+            f"- Modules at or above `95%`: `{at_or_above}/{len(module_metrics)}`.",
             f"- Total executable lines tracked in this table: `{total_executable_lines:,}`.",
             "- `Lines` shows covered/executable lines reported by `xcrun xccov`.",
             "- Coverage is gathered with `xcodebuild` and `xcrun xccov` from fresh `.xcresult` bundles.",
@@ -266,27 +323,75 @@ def replace_coverage_block(readme: str, new_block: str) -> str:
     return pattern.sub(new_block, readme, count=1)
 
 
-def replace_badges(readme: str, app_percent: float, modules_at_or_above_95: int, module_count: int) -> str:
-    app_badge = (
-        f"[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-"
-        f"{app_percent:.2f}%25-{badge_color(app_percent)})](#coverage)"
-    )
-    modules_badge = (
-        "[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-"
-        f"{modules_at_or_above_95}%2F{module_count}-{badge_color(100.0 * modules_at_or_above_95 / module_count)})](#coverage)"
-    )
+def modules_at_or_above_95(module_metrics: list[tuple[str, CoverageMetrics]]) -> int:
+    return sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
 
-    # `re.sub` with no match returns the string unchanged and raises nothing, so when the README
-    # carried no coverage badges at all this function was a guaranteed silent no-op: the full suite
-    # ran, the script exited 0, `run_full_test_suite.sh` printed "README coverage section updated."
-    # and neither badge had ever existed. `replace_coverage_block` above defends itself; this did not.
-    readme, replaced = re.subn(r"\[!\[App Coverage\]\([^)]+\)\]\(#coverage\)", app_badge, readme, count=1)
-    if replaced != 1:
-        raise RuntimeError("README.md is missing the App Coverage badge.")
-    readme, replaced = re.subn(r"\[!\[Module Coverage\]\([^)]+\)\]\(#coverage\)", modules_badge, readme, count=1)
-    if replaced != 1:
-        raise RuntimeError("README.md is missing the Module Coverage badge.")
-    return readme
+
+def badge_payloads(
+    app_metrics: CoverageMetrics, module_metrics: list[tuple[str, CoverageMetrics]]
+) -> dict[str, dict]:
+    """The two shields.io endpoint payloads, keyed by the file name each is published under.
+
+    Endpoint schema, which shields.io fetches and renders: `schemaVersion` pins the contract,
+    `label` is the grey half, `message` the coloured half, `color` the colour. Nothing else, and
+    no `cacheSeconds` — shields caches an endpoint response for a few minutes of its own accord and
+    a badge that is five minutes stale is not a problem worth a knob.
+    """
+    at_or_above = modules_at_or_above_95(module_metrics)
+    module_count = len(module_metrics)
+    return {
+        APP_BADGE_FILE: {
+            "schemaVersion": 1,
+            "label": APP_BADGE_LABEL,
+            "message": format_percent(app_metrics.percent),
+            "color": badge_color(app_metrics.percent),
+        },
+        MODULE_BADGE_FILE: {
+            "schemaVersion": 1,
+            "label": MODULE_BADGE_LABEL,
+            "message": f"{at_or_above}/{module_count}",
+            # Coloured by the *proportion* of modules clearing the bar, on the same ladder as a
+            # percentage, so "8/8" is bright green and "4/8" is red.
+            "color": badge_color(100.0 * at_or_above / module_count),
+        },
+    }
+
+
+def write_badges(
+    destination: Path,
+    app_metrics: CoverageMetrics,
+    module_metrics: list[tuple[str, CoverageMetrics]],
+) -> list[Path]:
+    destination.mkdir(parents=True, exist_ok=True)
+    written = []
+    for filename, payload in badge_payloads(app_metrics, module_metrics).items():
+        path = destination / filename
+        path.write_text(json.dumps(payload, indent=2) + "\n")
+        written.append(path)
+    return written
+
+
+def check_badges(readme: str) -> None:
+    """Refuse a README whose badges do not point at the payloads this script publishes.
+
+    The badges are no longer *written* here — CI publishes them to the `badges` branch and the
+    README carries a fixed endpoint URL per payload, so the local writer must leave them alone. What
+    it can still do is notice when the two have come apart, which is the drift this arrangement
+    invites: rename a payload, or move the branch, and both badges quietly become shields.io's
+    "invalid" placeholder with nothing going red.
+
+    Its ancestor, `replace_badges`, existed for the mirror-image reason — `re.sub` with no match
+    returns the string unchanged and raises nothing, so a README with no badges at all made the
+    rewrite a guaranteed silent no-op while `run_full_test_suite.sh` printed "README coverage
+    section updated." Neither failure is allowed to be silent.
+    """
+    for filename in (APP_BADGE_FILE, MODULE_BADGE_FILE):
+        if endpoint_badge_url(filename) not in readme:
+            raise RuntimeError(
+                f"README.md does not carry the endpoint badge for {filename}. It must link "
+                f"{endpoint_badge_url(filename)} — that is the URL shields.io reads the figure "
+                f"from, and it names the branch `{BADGE_BRANCH}` that CI force-pushes to."
+            )
 
 
 def report_one_bundle(result_bundle: Path, title: str) -> int:
@@ -316,28 +421,19 @@ def report_one_bundle(result_bundle: Path, title: str) -> int:
     return 0
 
 
-# The two provenance wordings. They differ because the two writers are answering different
-# questions for a reader who finds a number in the README and wants to know how stale it is: one is
-# "a human ran this on their Mac at some point", the other is "CI measured this on the commit that
-# is `main` right now".
+# The one provenance wording left. There used to be two, because CI wrote this block as well and a
+# reader had to be told which of the two writers a number came from. It does not any more: the block
+# is local-only by design, and the badges above it are CI-only, so the answer to "how stale is this"
+# is the same every time.
 FULL_SUITE_GENERATED_FROM = (
     "It is written from the coverage-enabled `.xcresult` bundles `./Scripts/run_full_test_suite.sh` "
     "produces on a Mac, one per scheme."
 )
 FULL_SUITE_PROVENANCE = (
-    "These numbers are from whoever last ran the full suite on a Mac. CI measures the same thing on "
-    "every run and prints it to the job summary; its attempt to record it here on a push to `main` "
-    "has so far been refused by branch protection every time, so a local run is the only writer "
-    "this file has actually had."
-)
-CI_GENERATED_FROM = (
-    "It is written by CI on every push to `main`, from the workspace-wide unit run the macOS job "
-    "measures with `-enableCodeCoverage YES`."
-)
-CI_PROVENANCE = (
-    "XCUITest is not in these figures: the step that measures coverage is the one passing "
-    "`-skip-testing:MimicUITests`, and the Linux job gathers no coverage at all. No floor is "
-    "enforced against them — this records, it does not gate."
+    "This table is as fresh as whoever last ran the full suite on a Mac, and nothing in CI writes "
+    "it. The two badges at the top of this file are the other way round — CI measures them on every "
+    "push to `main` and publishes them to the `badges` branch — so when the two disagree, the badges "
+    "are the current ones."
 )
 
 
@@ -349,9 +445,12 @@ def render_readme(
     generated_from: str,
     provenance: str,
 ) -> str:
-    """The whole rewrite as a string function, so `--self-test` can check it without touching disk."""
-    modules_at_or_above_95 = sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
-    readme = replace_badges(readme, app_metrics.percent, modules_at_or_above_95, len(module_metrics))
+    """The whole rewrite as a string function, so `--self-test` can check it without touching disk.
+
+    The badges are checked and left alone; only the block between the markers is rewritten. A README
+    edited between a measurement and a rewrite therefore keeps every other change it picked up.
+    """
+    check_badges(readme)
     return replace_coverage_block(
         readme,
         build_coverage_block(
@@ -431,7 +530,10 @@ def emit_json(result_bundle: Path, destination: Path) -> None:
     destination.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
-def update_readme_from_json(readme_path: Path, json_path: Path) -> None:
+def metrics_from_json(
+    json_path: Path,
+) -> tuple[CoverageMetrics, list[tuple[str, CoverageMetrics]]]:
+    """Read back what `--emit-json` wrote, on a machine with no Xcode and no bundle."""
     try:
         payload = json.loads(json_path.read_text())
         app_metrics = CoverageMetrics(
@@ -454,21 +556,35 @@ def update_readme_from_json(readme_path: Path, json_path: Path) -> None:
         raise RuntimeError(f"{json_path} is not a coverage payload this script wrote: {error}") from error
 
     if not module_metrics:
-        raise RuntimeError(f"{json_path} carries no modules; refusing to write a table with none.")
+        # The module badge's denominator is `len(module_metrics)`, so an empty list is not an empty
+        # badge — it is a division by zero, and a payload of eight modules that arrived carrying
+        # three would read `3/3` and look like a clean sweep. `split_workspace_metrics` refuses the
+        # partial table upstream for the same reason; this is the same refusal at the other end of
+        # the hand-off, where the file could have been truncated in between.
+        raise RuntimeError(f"{json_path} carries no modules; refusing to publish a badge with none.")
 
-    write_readme(
-        readme_path,
-        app_metrics,
-        module_metrics,
-        generated_from=CI_GENERATED_FROM,
-        provenance=CI_PROVENANCE,
-    )
+    return app_metrics, module_metrics
 
 
-FIXTURE_README = """# Fixture
+# Both URLs are written out longhand, character by character, and are **not** built from
+# `endpoint_badge_url`. A fixture derived from the mechanism moves with the mechanism: point
+# `BADGE_BRANCH` at a branch nothing is pushed to and a generated fixture would follow it, the check
+# would still pass, and both badges would 404 in silence. Written as literals, the same edit fails
+# here — which is the reminder that README.md carries these strings too and has to be edited with
+# them.
+FIXTURE_APP_BADGE_URL = (
+    "https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com"
+    "%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json"
+)
+FIXTURE_MODULE_BADGE_URL = (
+    "https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com"
+    "%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json"
+)
 
-[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
-[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
+FIXTURE_README = f"""# Fixture
+
+[![App Coverage]({FIXTURE_APP_BADGE_URL})](#coverage)
+[![Module Coverage]({FIXTURE_MODULE_BADGE_URL})](#coverage)
 
 Prose that must survive untouched.
 
@@ -478,13 +594,31 @@ Prose that must survive untouched.
 Trailing prose.
 """
 
+# What the README looked like before the badges were published — kept as a fixture because it is
+# exactly what `check_badges` has to refuse, and because it is what a reader will find in this
+# repository's history.
+FIXTURE_README_WITH_STATIC_BADGES = """# Fixture
+
+[![App Coverage](https://img.shields.io/badge/Mimic.app%20coverage-not%20measured-lightgrey)](#coverage)
+[![Module Coverage](https://img.shields.io/badge/modules%20at%20or%20above%2095%25-not%20measured-lightgrey)](#coverage)
+
+<!-- coverage:generated:start -->
+<!-- coverage:generated:end -->
+"""
+
 
 def self_test() -> int:
-    """Check the Mac-free half: the JSON round trip, both rewriters, and the refusals.
+    """Check the Mac-free half: the badge URLs, the badge payloads, the JSON round trip, the block
+    rewriter and every refusal.
 
     This is the only automated coverage the file has. The bundle-reading half needs `xcrun xccov`
     and a real `.xcresult`, so it is exercised only by the macOS job; everything below runs in a
     tenth of a second on the Linux gate alongside the other checkers.
+
+    Every expected value here is written out longhand. Nothing asks a function under test what the
+    right answer is — the badge URLs, the payload dictionaries and the colour ladder are all pinned
+    to literals, so reverting any of those mechanisms turns this red instead of moving the fixture
+    along with the bug.
     """
     import tempfile
 
@@ -494,34 +628,102 @@ def self_test() -> int:
         if not condition:
             failures.append(message)
 
+    # ---- the URLs, pinned to the strings README.md carries -------------------------------------
+    check(
+        endpoint_badge_url(APP_BADGE_FILE) == FIXTURE_APP_BADGE_URL,
+        "the app badge URL is not the one README.md links",
+    )
+    check(
+        endpoint_badge_url(MODULE_BADGE_FILE) == FIXTURE_MODULE_BADGE_URL,
+        "the module badge URL is not the one README.md links",
+    )
+    check(
+        raw_url("app-coverage.json")
+        == "https://raw.githubusercontent.com/srpadrono/mimic/badges/app-coverage.json",
+        "the raw URL is not where the badges branch publishes",
+    )
+    # Not a fixture, a consistency assertion: whatever `--print-badge-branch` tells the workflow to
+    # force-push to has to be the branch the URL above reads from, or CI publishes to one place and
+    # shields.io fetches from another.
+    check(
+        f"%2F{BADGE_BRANCH}%2F" in FIXTURE_APP_BADGE_URL,
+        "--print-badge-branch names a branch the badge URL does not read from",
+    )
+
+    # ---- the colour ladder, at every boundary --------------------------------------------------
+    for percent, expected_color in [
+        (100.0, "brightgreen"),
+        (95.0, "brightgreen"),
+        (94.99, "green"),
+        (90.0, "green"),
+        (89.99, "yellow"),
+        (80.0, "yellow"),
+        (79.99, "red"),
+        (0.0, "red"),
+    ]:
+        check(
+            badge_color(percent) == expected_color,
+            f"badge_color({percent}) is not {expected_color}",
+        )
+
     app = CoverageMetrics(percent=41.5, covered_lines=1_000, executable_lines=2_409)
     modules = [
         ("Domain.framework", CoverageMetrics(percent=96.0, covered_lines=960, executable_lines=1_000)),
         ("ControlPlane.framework", CoverageMetrics(percent=80.25, covered_lines=321, executable_lines=400)),
     ]
 
+    # ---- the payloads, as whole dictionaries ---------------------------------------------------
+    # Compared whole rather than key by key, so a fifth key appearing — a timestamp, a run URL, a
+    # `cacheSeconds` — fails here. shields.io ignores what it does not know, so an extra field would
+    # never show up on the badge; it would only make the payload stop being a pure function of the
+    # figures.
+    check(
+        badge_payloads(app, modules)
+        == {
+            "app-coverage.json": {
+                "schemaVersion": 1,
+                "label": "Mimic.app coverage",
+                "message": "41.50%",
+                "color": "red",
+            },
+            "module-coverage.json": {
+                "schemaVersion": 1,
+                "label": "modules at or above 95%",
+                # One of two modules clears 95%, and 50% of them is red on the same ladder.
+                "message": "1/2",
+                "color": "red",
+            },
+        },
+        "the badge payloads are not the two shields.io endpoint documents expected",
+    )
+
+    # ---- the block rewriter --------------------------------------------------------------------
     rendered = render_readme(
         FIXTURE_README, app, modules, generated_from="From a fixture.", provenance="Fixture note."
     )
-    check("not%20measured" not in rendered, "a badge still reads 'not measured' after a rewrite")
-    check("41.50%25" in rendered, "the app badge does not carry the measured percentage")
-    check("1%2F2" in rendered, "the module badge does not carry the at-or-above-95 count")
     check("`Domain.framework` | `96.00%` | `960/1,000`" in rendered, "a module row is missing or misformatted")
+    check("- Modules at or above `95%`: `1/2`." in rendered, "the at-or-above-95 count is wrong in the block")
     check("Prose that must survive untouched." in rendered, "prose outside the markers was lost")
     check("Trailing prose." in rendered, "prose after the block was lost")
     check(rendered.count("coverage:generated:start") == 1, "the start marker was duplicated or dropped")
     check(rendered.count("coverage:generated:end") == 1, "the end marker was duplicated or dropped")
+    # The badges are published, not written: a local full-suite run must leave them exactly as it
+    # found them, or the next person to run the suite commits a static badge over the live one.
+    check(FIXTURE_APP_BADGE_URL in rendered, "the app badge was rewritten by the local writer")
+    check(FIXTURE_MODULE_BADGE_URL in rendered, "the module badge was rewritten by the local writer")
+    check("41.50%25" not in rendered, "the local writer baked a figure into a badge URL")
 
-    # Idempotence is what makes "commit only when the numbers moved" true: rewriting the *rendered*
-    # README with the same figures has to produce the same bytes, markers and badges included.
+    # Idempotence: rewriting the *rendered* README with the same figures has to produce the same
+    # bytes. Nothing in CI depends on that any more — the badge branch is force-pushed whatever it
+    # says — but a human commits this block, and a full-suite run that dirties the tree on identical
+    # figures is a diff nobody can review.
     again = render_readme(
         rendered, app, modules, generated_from="From a fixture.", provenance="Fixture note."
     )
     check(again == rendered, "rewriting with unchanged figures produced a different README")
 
+    # ---- the JSON round trip, and out the other side as files ----------------------------------
     with tempfile.TemporaryDirectory() as tmp:
-        readme_path = Path(tmp) / "README.md"
-        readme_path.write_text(FIXTURE_README)
         json_path = Path(tmp) / "coverage.json"
         json_path.write_text(
             json.dumps(
@@ -531,18 +733,46 @@ def self_test() -> int:
                 }
             )
         )
-        update_readme_from_json(readme_path, json_path)
-        from_json = readme_path.read_text()
-        check("41.50%25" in from_json, "--from-json did not rewrite the app badge")
-        check(CI_PROVENANCE in from_json, "--from-json did not use the CI provenance wording")
+        round_tripped_app, round_tripped_modules = metrics_from_json(json_path)
+        check(round_tripped_app == app, "the app figures did not survive the JSON round trip")
+        check(round_tripped_modules == modules, "the module figures did not survive the JSON round trip")
+
+        badge_dir = Path(tmp) / "badges"
+        written = write_badges(badge_dir, round_tripped_app, round_tripped_modules)
+        check(
+            sorted(path.name for path in written) == ["app-coverage.json", "module-coverage.json"],
+            "--emit-badges wrote something other than the two payload files",
+        )
+        check(
+            json.loads((badge_dir / "app-coverage.json").read_text())
+            == {
+                "schemaVersion": 1,
+                "label": "Mimic.app coverage",
+                "message": "41.50%",
+                "color": "red",
+            },
+            "the app payload on disk is not the document shields.io expects",
+        )
+        check(
+            (badge_dir / "module-coverage.json").read_text().endswith("}\n"),
+            "a payload was written without a trailing newline",
+        )
 
         json_path.write_text("{\"app\": {}}")
         try:
-            update_readme_from_json(readme_path, json_path)
+            metrics_from_json(json_path)
             failures.append("a malformed payload was accepted")
         except RuntimeError:
             pass
 
+        json_path.write_text(json.dumps({"app": {"name": "Mimic.app", **asdict(app)}, "modules": []}))
+        try:
+            metrics_from_json(json_path)
+            failures.append("a payload carrying no modules was accepted")
+        except RuntimeError:
+            pass
+
+    # ---- the refusals --------------------------------------------------------------------------
     try:
         split_workspace_metrics({"Domain.framework": app})
         failures.append("a report missing eight of nine targets was accepted")
@@ -555,6 +785,14 @@ def self_test() -> int:
     except RuntimeError:
         pass
 
+    try:
+        render_readme(
+            FIXTURE_README_WITH_STATIC_BADGES, app, modules, generated_from="x", provenance="y"
+        )
+        failures.append("a README still carrying the old static badges was accepted")
+    except RuntimeError as error:
+        check(APP_BADGE_FILE in str(error), "the refusal does not name the payload the README must link")
+
     for failure in failures:
         print(f"  FAIL {failure}")
     print(
@@ -566,14 +804,20 @@ def self_test() -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Read coverage from .xcresult bundles: rewrite README, or print a Markdown report."
+        description=(
+            "Read coverage from .xcresult bundles: rewrite the README's generated block, print a "
+            "Markdown report, or write the two shields.io endpoint payloads CI publishes."
+        )
     )
     parser.add_argument(
-        "--readme", default="README.md", help="Path to README.md (--results-dir and --from-json modes)"
+        "--readme", default="README.md", help="Path to README.md (--results-dir mode)"
     )
     parser.add_argument(
         "--results-dir",
-        help="Directory of per-scheme bundles, as Scripts/run_full_test_suite.sh produces. Rewrites the README.",
+        help=(
+            "Directory of per-scheme bundles, as Scripts/run_full_test_suite.sh produces. Rewrites "
+            "the README's generated block. Never touches the badges."
+        ),
     )
     parser.add_argument(
         "--result-bundle",
@@ -585,27 +829,61 @@ def main() -> None:
     )
     parser.add_argument(
         "--from-json",
-        help="A file written by --emit-json. Rewrites the README from it. Needs no Xcode.",
+        help="A file written by --emit-json. Needs no Xcode. Requires --emit-badges.",
+    )
+    parser.add_argument(
+        "--emit-badges",
+        help=(
+            "With --from-json: write the two shields.io endpoint payloads into this directory, for "
+            "the workflow to force-push to the badges branch."
+        ),
+    )
+    parser.add_argument(
+        "--print-badge-branch",
+        action="store_true",
+        help="Print the branch the badge payloads are published to, and exit.",
     )
     parser.add_argument(
         "--self-test",
         action="store_true",
-        help="Check the rewriters and the JSON round trip against a fixture. Needs no Xcode.",
+        help="Check the badge payloads, the rewriter and the JSON round trip. Needs no Xcode.",
     )
     parser.add_argument("--title", default="Code coverage", help="Heading for --result-bundle output.")
     args = parser.parse_args()
 
-    modes = [bool(args.results_dir), bool(args.result_bundle), bool(args.from_json), args.self_test]
+    modes = [
+        bool(args.results_dir),
+        bool(args.result_bundle),
+        bool(args.from_json),
+        args.print_badge_branch,
+        args.self_test,
+    ]
     if sum(modes) != 1:
-        parser.error("pass exactly one of --results-dir, --result-bundle, --from-json or --self-test")
+        parser.error(
+            "pass exactly one of --results-dir, --result-bundle, --from-json, "
+            "--print-badge-branch or --self-test"
+        )
     if args.emit_json and not args.result_bundle:
         parser.error("--emit-json only means something with --result-bundle")
+    if args.emit_badges and not args.from_json:
+        parser.error("--emit-badges only means something with --from-json")
+    # `--from-json` used to rewrite README.md, and refusing it without `--emit-badges` is what stops
+    # a caller written against that shape from silently doing nothing. The README's generated block
+    # is written by `--results-dir` and by nothing else now.
+    if args.from_json and not args.emit_badges:
+        parser.error("--from-json needs --emit-badges: it no longer writes the README")
 
     if args.self_test:
         raise SystemExit(self_test())
 
+    if args.print_badge_branch:
+        print(BADGE_BRANCH)
+        return
+
     if args.from_json:
-        update_readme_from_json(Path(args.readme).resolve(), Path(args.from_json).resolve())
+        app_metrics, module_metrics = metrics_from_json(Path(args.from_json).resolve())
+        for path in write_badges(Path(args.emit_badges).resolve(), app_metrics, module_metrics):
+            print(f"{path}\n{path.read_text()}", end="")
         return
 
     if args.result_bundle:
@@ -614,8 +892,7 @@ def main() -> None:
             # Raises rather than printing a reason and exiting 1, unlike `report_one_bundle` above:
             # nobody is reading this step's stdout as a report, and the caller wants a file or a
             # failure. The workflow marks the step `continue-on-error`, so the failure surfaces as a
-            # warning and the README simply goes on saying whatever it last said — which, until the
-            # first successful recording, is `not measured`.
+            # warning and the badges go on showing whatever was last published.
             emit_json(bundle, Path(args.emit_json).resolve())
             return
         raise SystemExit(report_one_bundle(bundle, args.title))

--- a/Scripts/update_readme_coverage.py
+++ b/Scripts/update_readme_coverage.py
@@ -326,8 +326,9 @@ FULL_SUITE_GENERATED_FROM = (
 )
 FULL_SUITE_PROVENANCE = (
     "These numbers are from whoever last ran the full suite on a Mac. CI measures the same thing on "
-    "every run and records it here on every push to `main`, so this wording means a local run "
-    "overtook the last recorded one."
+    "every run and prints it to the job summary; its attempt to record it here on a push to `main` "
+    "has so far been refused by branch protection every time, so a local run is the only writer "
+    "this file has actually had."
 )
 CI_GENERATED_FROM = (
     "It is written by CI on every push to `main`, from the workspace-wide unit run the macOS job "


### PR DESCRIPTION
Two things: the README had lost its proportions, and its coverage badges have been lying since the day they were added.

## 1. The README was a third Testing

`## Testing` had grown to **137 lines** — more than Why Mimic, Install, Quickstart and Journeys combined (83). Someone opening the file to learn what Mimic is met an essay on GitHub Actions concurrency limits. Most of it arrived in #57 and #58.

| | Before | After |
|---|--:|--:|
| `## Testing` | 137 | **49** |
| README total | 414 | **324** |

Nothing is lost. The measurement mechanics, the `record-coverage` design notes and the branch-protection account **moved to `ci.md`**. The shard essay — concurrency cap, run #89's queue, the 51/53/54 split — is **deleted**, because `ci.md` already told it better after #58. One home per fact.

The floor is not arbitrary: `check_doc_counts.py` asserts specific sentences and reports a removed one as a *lost claim*. Cutting further meant dropping something it guards.

## 2. The badges have never worked, and now they will

Both badges have read `not measured` for this repository's entire history. **The measurement was never the problem** — `record-coverage` computes it on every push to `main` and always has. Getting it into a file was:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
##[warning]Could not push the coverage update to main — the diff is in the job summary.
```

The job warns rather than reddening a commit whose tests passed — correct behaviour, and exactly why six merges went by without anyone noticing.

**The fix is not to let a bot past that rule.** It is to stop asking `main` for permission to publish a number. Two shields.io endpoint payloads now go to an orphan `badges` branch, force-pushed as a single parentless commit, and the README's badges read from there:

```json
{ "schemaVersion": 1, "label": "Mimic.app coverage", "message": "72.41%", "color": "…" }
```

The branch carries no source, holds two files and one commit forever, and **`main` keeps exactly the protection it has today.** No bypass, no token, no widened permissions — `contents: write` stays on this one job, and the workflow default stays `contents: read`.

### What went, and what was kept

The push to `main` is gone with its `[skip ci]` marker — and the marker went because the *hazard* did, not because it stopped mattering. `push:` names `branches: [main]`, so writing to `badges` triggers nothing. The comment says so, and says the marker comes back the day a push to `main` does.

The no-timestamp rule survives for the in-README block, which a human still commits and which must stay byte-identical when the measurement has not moved.

The block is now local-only **by construction**: `--from-json` refuses to run without `--emit-badges`, so the only writer that section has ever actually had is the only one that can be. `replace_badges` is deleted too — a local full-suite run must not overwrite live badges with static text.

The job still never gates. Both payloads go to the step summary *before* any git runs, so every failure mode still leaves the figures on the run page.

### The same false claim was in three other places

`CONTRIBUTING.md`, `mimic-build-and-test/SKILL.md`, and — the one that mattered — `update_readme_coverage.py`'s own `FULL_SUITE_PROVENANCE`, which is text a **local** run writes *into* the README. The next full suite anyone ran would have re-injected the false sentence into the file this PR corrects. All fixed.

## Verification

All gates pass: `check_doc_counts` (+`--self-test`), `check_module_edges`, `check_compiler_settings`, `check_lockfiles`, `check_skills`, `check_ui_shards` (+`--self-test`), `check_house_rules` (+`--self-test`), `update_readme_coverage --self-test`. `ci.yml` parses; `bash -n` on every shell touched.

The badge self-test's fixture URLs are typed out character by character and the fixture README is built from **those literals**, not from `endpoint_badge_url` — so repointing the branch fails the gate rather than dragging the fixture along. Verified by repointing `BADGE_BRANCH` and watching it go red, then restoring it.

The orphan-branch recipe was rehearsed against a local bare remote — first run, second run, and a shallow clone — confirming the pushed branch holds exactly two files and exactly one commit each time.

## Expect this on merge

**Both badges will 404 briefly.** Publishing is gated on `push` to `main`, so nothing is written from this PR; the `badges` branch is created by the first run *after* merge, and the badges render only once it finishes (~33 min). Worth expecting rather than debugging.

Two smaller notes: shields.io caches endpoint responses for a few minutes, so a badge lags its run slightly. And this job was renamed from `Record coverage in README` to `Publish coverage badges` — it only ever runs on `main`, so it cannot have been a required check, but the name has moved if it was referenced anywhere.

## Noted, not done

- `## Architecture` is now the largest section at 68 lines, ~20 duplicating `references/one-host.md`.
- `## Driving Mimic from a test suite` (47) duplicates `docs/CLI.md#environment`.
- `check_doc_counts.py` has a fragile `re.S` pattern that needs a trailing em dash to stop; worth an anchor before someone rewraps that paragraph.