### PR TITLE
Measure coverage with the window included, by merging the four result bundles

### DIFF
--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -1,6 +1,6 @@
 # What CI actually covers
 
-CI runs on every pull request and on every push to `main`, in **five job definitions and seven
+CI runs on every pull request and on every push to `main`, in **six job definitions and eight
 jobs** — the UI one is a three-leg matrix. Both runners are free: GitHub does not meter standard
 hosted runners on public repositories, macOS included.
 
@@ -8,29 +8,78 @@ hosted runners on public repositories, macOS included.
 |-----|--------|--------|
 | `linux` | `ubuntu-latest`, `swift:6.2` | `Package.swift`, the portable suites, and every cheap gate: house rules, the three manifest checks, documented counts, skill layout, UI-shard coverage, the coverage-writer self-test |
 | `macos-checks` | `macos-26` | `tuist generate`, the Debug build, the app-level suites **with the coverage measurement**, the CLI end-to-end check (non-gating), the Release gate and its warning inventory |
-| `macos-ui` (×3) | `macos-26` | The XCUITest suite, sharded across three runners by test class |
+| `macos-ui` (×3) | `macos-26` | The XCUITest suite, sharded across three runners by test class, each shard also measuring coverage |
 | `ui-suite` | `ubuntu-latest` | Rolls the three shard results into one status check |
-| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: publishes the measured coverage as two shields.io endpoint payloads on the orphan `badges` branch, which README.md's badges read |
+| `coverage` | `macos-26` | Pushes to `main` only, and downstream of all four macOS jobs: merges their four result bundles and emits the figures from the union |
+| `record-coverage` | `ubuntu-latest` | Pushes to `main` only: publishes those figures as two shields.io endpoint payloads on the orphan `badges` branch, which README.md's badges read |
 
 `record-coverage` is the only job holding `contents: write`, and it holds it precisely so that the
-jobs compiling code out of a pull request do not — see the comments above it and above `Emit coverage
-figures`. It needs `macos-checks` and **not** the UI shards, because coverage is measured in that job
-and because this repository's UI suite is documented as ending red on a test that passed on its
-retry; making the publishing wait on the shards would mean the badges update only on runs where a
-flake happened not to fire.
+jobs compiling code out of a pull request do not — see the comments above it in the workflow.
 
-## Coverage: measured every run, published to a branch of its own
+**Required status checks** are `Build and test (Linux)`, `Build, unit suites, Release, CLI e2e
+(macOS)` and `UI suite`. Neither coverage job belongs in that list: they run only on pushes to
+`main`, so on a pull request they never report, and a required check that never reports blocks the
+merge forever.
 
-The measurement lives inside `macos-checks` rather than in a job of its own. Its `Test (unit suites)`
-step runs the `Mimic-Workspace` scheme with `-enableCodeCoverage YES` and writes the result bundle to
-a named path; the `Coverage report` step reads that bundle with `xcrun xccov` and prints a per-target
-table into the **job summary**, so "how much of this is actually exercised" is a link away rather
-than a script somebody has to remember to run. On a red run the bundle is uploaded as the
-`xcresult-unit` artifact, which is where per-file detail lives.
+## Coverage: measured every run, merged, published to a branch of its own
 
-Two things sit outside the figures, both structurally. **XCUITest**, because the step doing the
-measuring is the one passing `-skip-testing:MimicUITests` — the UI suite runs in three jobs beside
-it. And **everything the Linux job runs**, because gathering coverage needs the Xcode toolchain.
+Four jobs measure and a fifth merges. `macos-checks` runs the `Mimic-Workspace` scheme with
+`-enableCodeCoverage YES` and `-skip-testing:MimicUITests`; each of the three `macos-ui` shards runs
+its slice of XCUITest with the same flag. All four write a named `-resultBundlePath`, and the
+`Coverage report` step in `macos-checks` prints its own per-target table into the **job summary** on
+every run, pull requests included, so "how much of this is actually exercised" is a link away rather
+than a script somebody has to remember to run.
+
+On a push to `main`, each of the four tars its bundle and uploads it, and the `coverage` job merges
+them.
+
+### Why the bundles travel, and not the numbers
+
+**Coverage is a set union over executed lines, not a sum.** A line the unit suites reach and a UI
+test also reaches is one covered line in the union, not two. Four sets of nine per-target numbers
+therefore cannot be combined into one set of nine by any arithmetic — the numbers have already thrown
+away *which* lines. Adding double-counts and can exceed the denominator; taking the per-target
+maximum discards everything one suite reached that the other did not. Only the line-level data
+merges, and that lives in the `.xcresult`.
+
+So the bundles move, as `.tar.gz` — a bundle is thousands of small files and `upload-artifact` posts
+each one, which turns a directory upload into a step measured in tens of minutes, while a compressed
+tarball is one file. `xcrun xcresulttool merge` does the union, and `Scripts/update_readme_coverage.py`
+reads the merged bundle exactly as it read the single one.
+
+The workflow comment above `Package the coverage bundle` records that this reverses an earlier
+decision, and why: the old design handed nine numbers across as a job output and argued that moving
+hundreds of megabytes to re-read nine numbers was waste. It was right about the cost and wrong about
+the requirement.
+
+### Where this can produce no gain, and how you would know
+
+The app under test is sandboxed (`App/Mimic.entitlements`), and an instrumented binary writes its
+`.profraw` to a path baked in at build time — under DerivedData, outside the app's container. If the
+sandbox refuses that write, the shards' bundles carry coverage for the test target and nothing for
+the app or the frameworks it links, which is where `AppFeatures` lives.
+
+That is why the `coverage` job prints **two** tables into the summary: the unit-only figures beside
+the merged ones. `AppFeatures` identical in both means the UI suite is still invisible to the
+measurement, and the next move is the app's entitlements in CI rather than anything in this pipeline.
+A union with an empty set is the same set, so the failure mode here is "no gain" — never a wrong
+number.
+
+### What the job refuses to publish
+
+Two refusals, both ending in "the badges go on showing the last figures that were published":
+
+- **Fewer bundles than `EXPECTED_COVERAGE_BUNDLES`.** A shard that died before writing one leaves a
+  union missing everything that shard covered — a *lower* number, published with nothing to say
+  anything is missing. That literal is `1 + the number of legs in macos-ui`, written down because a
+  job cannot read another job's matrix, and `Scripts/check_ui_shards.py` fails the Linux job if it
+  and the matrix disagree.
+- **A merge that fails.** `xcresulttool merge` is the one command in that job whose behaviour could
+  not be checked before it landed, so a future Xcode that spells it differently is a warning and a
+  note in the summary, never a red X on a commit whose tests passed.
+
+**Everything the Linux job runs** is still outside the figures, structurally: gathering coverage
+needs the Xcode toolchain.
 
 ### The two figures go to two different places, on purpose
 
@@ -95,9 +144,10 @@ so moving the branch fails the gate instead of silently 404ing both badges.
   jobs compile and run code out of a pull request; a write token there would widen the blast radius
   of anything going wrong in one to "can push". This job runs one stdlib Python script and some git —
   no build, no test, no repository code.
-- **A few hundred bytes cross between the two, not the bundle.** The macOS job emits the figures as
-  JSON (`--emit-json`) and hands them on as a job output; the `.xcresult` is hundreds of megabytes
-  and stays on the runner that made it. That hand-off is also what lets the publishing run on Linux.
+- **A few hundred bytes cross into this job, not a bundle.** The `coverage` job emits the merged
+  figures as JSON (`--emit-json`) and hands them on as a job output. The bundles themselves stop
+  there, on macOS, because merging them needs `xcresulttool` and nothing after the merge does — which
+  is what lets the publishing run on Linux with a write token and no Xcode.
 - **Nothing generated carries a timestamp, run number or run URL.** The branch is force-pushed to one
   commit regardless, so this no longer protects CI from anything — but the README block is still a
   pure function of the figures, because a *human* commits that one and an unchanged local measurement
@@ -174,6 +224,13 @@ Three things about the split are load-bearing, and the workflow's header argues 
   fifth macOS job — another shard, or the Release gate split out of `macos-checks` — expect it to
   queue, and bring a measurement rather than the documented number. That is also why the Release gate
   is not a job of its own: it would cost a shard slot and lengthen the run.
+
+  **The `coverage` job is a fifth macOS job and does not queue, which sharpens the rule rather than
+  breaking it.** The cap is on jobs running *at the same time*; that one declares
+  `needs: [macos-checks, macos-ui]`, so it starts only once all four have finished and returned their
+  slots. It asks for a slot that is free by construction. The question to ask of a new macOS job is
+  therefore not "is it the fifth" but "does it run beside the other four or after them" — beside
+  costs about a shard's length, after costs only its own.
 - **Each shard builds for itself** rather than downloading products from a shared
   `build-for-testing` job. The shards run concurrently, so the ~5-minute Debug build was never on the
   critical path more than once; building once would move it onto a *serial* job ahead of every shard
@@ -189,6 +246,16 @@ runs in the Linux job and in `Scripts/ci.sh`, and fails on a class in no shard, 
 shard naming a class that no longer exists (which `xcodebuild` reports as "no tests to run", exit 0).
 It reads the workflow as text and `MimicUITests/` as text — no PyYAML, because the Linux container
 installs `python3-minimal`.
+
+It has a fourth verdict, one level up and the same shape: **`EXPECTED_COVERAGE_BUNDLES` disagreeing
+with the shard count.** The `coverage` job merges one bundle per test-running job and cannot count
+the shards for itself, since a job cannot read another job's `matrix`, so the total is a literal.
+Add a fourth shard and leave the literal at 4 and that job merges three shards' coverage believing it
+has all of them, publishing a figure lower than the truth with nothing anywhere to say a shard is
+missing. Lower the literal and it refuses forever. Both are silent; this makes them a red Linux job.
+
+`--self-test` drives all of it over a workflow and a suite tree invented inside the script — never
+read off disk, never produced by the parsers — which is what makes it evidence about them.
 
 Today's split is **51 / 53 / 54** across the ten classes, against an ideal third of 52.7, balanced by
 **test count** — a proxy for time rather than time itself, and a defensible one since nearly every

--- a/.github/actions/macos-setup/action.yml
+++ b/.github/actions/macos-setup/action.yml
@@ -80,10 +80,13 @@ runs:
     # Tuist resolves the SPM dependencies into the workspace, so this cache is what keeps a run from
     # rebuilding Vapor and GRDB from source every time.
     #
-    # Now restored by five jobs per run rather than one. They share a key, so the first run on a new
-    # `Tuist/Package.resolved` has five concurrent misses and five concurrent saves of the same
-    # content; `actions/cache` resolves that by refusing the duplicate saves with a warning, which is
-    # noise rather than a failure. Every run after it is five hits.
+    # Now restored by four jobs per run rather than one — this action's four callers. They share a
+    # key, so the first run on a new `Tuist/Package.resolved` has four concurrent misses and four
+    # concurrent saves of the same content; `actions/cache` resolves that by refusing the duplicate
+    # saves with a warning, which is noise rather than a failure. Every run after it is four hits.
+    #
+    # The workflow's `coverage` job is a fifth macOS job and is not one of them: it runs no build,
+    # so it calls neither this action nor Tuist.
     - name: Cache Tuist dependencies
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -102,8 +105,8 @@ runs:
     #
     # No macOS job has a counterpart to the Linux `Lockfiles agree` step, because that check is
     # platform-independent and running it twice buys nothing — but it means this line is the only
-    # thing standing between a re-resolved Tuist lockfile and a green run. It is now run by all five
-    # macOS jobs, so the guarantee holds on whichever of them a re-resolve happens to hit.
+    # thing standing between a re-resolved Tuist lockfile and a green run. It is now run by all four
+    # jobs that build, so the guarantee holds on whichever of them a re-resolve happens to hit.
     - name: Resolve and generate
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,16 @@ name: CI
 #     ────────────────────────
 #                    4 slots
 #
+# There is a **fifth** macOS job — `coverage`, near the bottom of this file — and it is outside that
+# budget rather than an exception to it. The cap is on jobs running *at the same time*, and that one
+# declares `needs: [macos-checks, macos-ui]`, so it cannot start until all four above have finished
+# and given their slots back. It asks for a slot that is free by construction. What it costs is wall
+# clock on pushes to `main`, after the last shard reports, and nothing at all on a pull request.
+#
+# The rule the paragraph above is really stating, then: **a fifth *concurrent* macOS job queues for
+# about the length of a shard.** A fifth job downstream of the other four does not. Before adding
+# one, ask which kind it is.
+#
 # Fewer, larger shards is the right trade under an observed cap of four. Three shards of ~53 tests
 # each are longer than four of ~40, but nothing queues, and a shard that runs is worth more than a
 # shard that waits: the four-shard split spent 19m26 of wall clock on a slot that did not exist.
@@ -153,6 +163,9 @@ name: CI
 #     macos-ui  (51/53/54)    ~30m    ~1m setup + ~5m Debug + ~1m30 test-target compile
 #                                     + 54 × 26s ≈ 23m24 of tests on the heaviest shard
 #     ui-suite                 ~0m    Linux; rolls the three shard results into one status check
+#     coverage           pushes only  macOS; downloads four result bundles, merges them, publishes
+#                                     the figures. Downstream of everything above, so it adds to a
+#                                     push to `main` and nothing to a pull request.
 #
 # So: **96 minutes originally, 43 measured with four shards, about 30 expected with three.** The
 # saving is not from running less — it is the same 158 tests either way — it is from stopping asking
@@ -414,10 +427,15 @@ jobs:
   # This is the old `macos` job with the UI step lifted out of the middle of it. The rename is not
   # cosmetic — it is what stops "the macOS job" meaning two unrelated things — but it does have one
   # consequence outside this file: **required status checks in branch protection are configured by
-  # job name.** `Build and test (macOS)` no longer exists as a check. Whoever merges this must update
-  # the branch rules to require `Build, unit suites, Release, CLI e2e (macOS)` and `UI suite`, or
-  # `main` accepts a commit no macOS job ever looked at. The `UI suite` job at the bottom exists
-  # partly so that the second of those names never has to change again when the shard count does.
+  # job name.** `Build and test (macOS)` no longer exists as a check; the branch rules were updated
+  # to require `Build, unit suites, Release, CLI e2e (macOS)` and `UI suite` instead. The `UI suite`
+  # job further down exists partly so that the second of those names never has to change again when
+  # the shard count does.
+  #
+  # Neither `coverage` nor `Publish coverage badges` belongs in that list, and adding one would be a
+  # mistake of the kind this file argues against everywhere else: they run only on pushes to `main`,
+  # so on a pull request they never report at all — a required check that never reports blocks the
+  # merge forever — and a coverage measurement is not a verdict on a commit.
   macos-checks:
     name: Build, unit suites, Release, CLI e2e (macOS)
     runs-on: macos-26
@@ -425,12 +443,6 @@ jobs:
     # run #89, so this is generous by more than twofold and still tight enough that a wedged runner
     # is cut loose within the hour.
     timeout-minutes: 45
-
-    # The measured coverage figures, handed to `record-coverage` below. Empty on every run that is
-    # not a push to `main`, and on any run that failed before the measurement — that job treats an
-    # empty value as "nothing to record" rather than as an error.
-    outputs:
-      coverage: ${{ steps.figures.outputs.json }}
 
     # DerivedData inside the checkout, and **every** xcodebuild step below passes it.
     #
@@ -477,12 +489,16 @@ jobs:
       # rendering tests. The rest of the suite already ran on Linux, and XCUITest runs in the sharded
       # job below — `-skip-testing:MimicUITests` is what keeps the two from overlapping.
       #
-      # This is also the only step in this workflow that *measures* how much of this code the tests
-      # reach, rather than reading the tree and reasoning about it. Until it carried
-      # `-enableCodeCoverage YES`, both README badges said `not measured` and meant it: every claim
-      # in this repository about what is and is not tested rested on grep.
-      # `Scripts/run_full_test_suite.sh` passes the flag too, but it needs a Mac and a human who
-      # remembers to run it, and no CI step passed it at all.
+      # This step *measures* how much of this code the tests reach, rather than reading the tree and
+      # reasoning about it. Until it carried `-enableCodeCoverage YES`, both README badges said
+      # `not measured` and meant it: every claim in this repository about what is and is not tested
+      # rested on grep. `Scripts/run_full_test_suite.sh` passes the flag too, but it needs a Mac and
+      # a human who remembers to run it, and no CI step passed it at all.
+      #
+      # It is no longer the *only* such step. The three UI shards carry the flag too, and the
+      # `coverage` job near the bottom of this file merges all four bundles into the union the badges
+      # publish. This one is still the half that runs on every pull request, and its table is what a
+      # reviewer reads on a run that publishes nothing.
       #
       # `-resultBundlePath` is what makes the bundle findable afterwards. Without it xcodebuild
       # writes to `$DERIVED_DATA/Logs/Test/`, and the coverage step below would have to find its
@@ -541,47 +557,53 @@ jobs:
             --title 'Code coverage (unit suites, XCUITest excluded)' \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # (c): the same figures again, as a few hundred bytes of JSON handed to the `record-coverage`
-      # job at the bottom of this file, which turns them into the two badge payloads.
+      # (c): the bundle itself, tarred and handed to the `coverage` job at the bottom of this file,
+      # which merges it with the three UI shards' bundles and emits the badge figures from the union.
       #
-      # A **job output**, not an artifact, and not three more lines on that job. Two constraints
-      # meet here. `contents: write` must not live on this job — it is the one that compiles and
-      # runs code out of a pull request, and a write token here would widen the blast radius of
-      # anything going wrong in that to "can push to `main`". And the `.xcresult` this reads is
-      # several hundred megabytes, so handing the *bundle* to a second job would move all of it
-      # between runners so the other end could re-read nine numbers out of it. An output carries
-      # exactly the nine numbers, costs nothing, and needs no `download-artifact` — which this
-      # workflow has never pinned, and a SHA is not a thing to guess at.
+      # **This used to be nine numbers in a job output, and that was wrong.** The comment here argued
+      # that moving several hundred megabytes between runners so the other end could re-read nine
+      # numbers was waste, and about the cost it was right. About the requirement it was not.
+      # Coverage is a **set union over executed lines, not a sum**: a line the unit suites reach and
+      # a UI test also reaches is one covered line, not two. Four sets of nine numbers therefore
+      # cannot be combined into one set of nine by any arithmetic — not by adding, not by taking the
+      # maximum — because the numbers have thrown away *which* lines. Only the line-level data can be
+      # merged, and that lives in the bundle. So the bundle travels, tarred.
       #
-      # `continue-on-error`, for the same reason the summary step above carries it and no weaker: a
-      # coverage measurement is not a verdict on a commit, and a step that reddens a run whose tests
-      # all passed teaches people to ignore red. It matters more here than there, because the exact
-      # names `xccov` reports targets under in a *workspace-wide* bundle could not be checked from
-      # where this was written — no Mac, no Xcode — and `--emit-json` deliberately refuses to write
-      # a partial table, all nine targets or none, rather than shrinking the badge's denominator
-      # into a pass.
+      # Tarred, and not handed to `upload-artifact` as a directory. An `.xcresult` is thousands of
+      # small files; the uploader walks and posts each one, which turns a bundle into a step measured
+      # in tens of minutes. One `.tar.gz` is one file, and a bundle is mostly JSON, so it compresses
+      # hard. `retention-days: 1` because nothing reads it after the job three below.
       #
-      # That refusal is safe to leave loud-but-not-fatal because its failure announces itself: no
-      # figures means nothing is published, and the badges go on showing the figures from the last
-      # push that did measure — visibly stale rather than quietly wrong. A silent wrong number is the
-      # outcome worth engineering against; an old one is not.
+      # Only on a push to `main`, for the reason the emit step gave: on a pull request there is
+      # nowhere to record the result, and the numbers describe the merged commit anyway. Keeping it
+      # off pull requests is also what keeps this change off the feedback path the sharding bought.
       #
-      # Only on a push to `main`: on a pull request there is nowhere to record the result, and the
-      # numbers describe the merged commit anyway.
-      - name: Emit coverage figures
-        id: figures
+      # **No `if: always()`, deliberately, and this differs from the UI shards.** A step with no
+      # condition is skipped when an earlier one failed, so a genuinely failing unit suite publishes
+      # no coverage — which is right, because the badge should not move for a commit whose tests are
+      # red. The shards below *do* carry `!cancelled()`, because that suite is documented to end red
+      # on a test that passed on its retry, and a flake must not be what decides whether the figures
+      # are recorded.
+      - name: Package the coverage bundle
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        continue-on-error: true
         run: |
-          python3 Scripts/update_readme_coverage.py \
-            --result-bundle .artifacts/coverage/UnitTests.xcresult \
-            --emit-json .artifacts/coverage/coverage.json
-          cat .artifacts/coverage/coverage.json
-          {
-            echo 'json<<COVERAGE_JSON_EOF'
-            cat .artifacts/coverage/coverage.json
-            echo 'COVERAGE_JSON_EOF'
-          } >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          tar -C .artifacts/coverage -czf .artifacts/UnitTests.xcresult.tar.gz UnitTests.xcresult
+          ls -lh .artifacts/UnitTests.xcresult.tar.gz
+
+      # `if-no-files-found: warn` rather than `error`, for the rule this file applies to every
+      # coverage step: a measurement never reddens a commit whose tests passed. A bundle that did not
+      # arrive is caught at the other end instead — the `coverage` job counts what it downloaded
+      # against `EXPECTED_COVERAGE_BUNDLES` and publishes nothing if the count is short, so the
+      # badges go visibly stale rather than quietly dropping whatever the missing job covered.
+      - name: Upload the coverage bundle
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-bundle-unit
+          path: .artifacts/UnitTests.xcresult.tar.gz
+          retention-days: 1
+          if-no-files-found: warn
 
       # The seam nothing else in this workflow reaches: a real process launch, the discovery file on
       # disk, a real control socket, and `mimic` as a binary rather than `MimicCommand.run(arguments:)`
@@ -922,6 +944,30 @@ jobs:
       # path so the three uploads below cannot collide. `tee` for the reason that step documents: a
       # compile failure in the test target produces a bundle with `totalTestCount: 0`, so the errors
       # exist only in this output.
+      #
+      # `-enableCodeCoverage YES` here is what the `coverage` job at the bottom of this file exists
+      # to use, and it closes the gap that made the first published figure meaningless. The badge
+      # read `Mimic.app coverage 46.67%` and `modules at or above 95% 5/8`, with `AppFeatures` — the
+      # 14,990-line SwiftUI and workflow layer, and the only module these 158 tests touch — measured
+      # at 85.32%. It was measured with `-skip-testing:MimicUITests`, so the entire XCUITest suite
+      # contributed nothing to the number that was published about how well this window is tested.
+      #
+      # It is on for every run, not just the pushes that publish. What CI measures should be what CI
+      # ran, and a flag that is set on `main` and clear on pull requests is a flag whose effect on
+      # this suite nobody sees until it is too late to attribute. Instrumentation costs a few per
+      # cent of a step dominated by app launches and `waitForExistence`, against a 60-minute timeout
+      # the heaviest shard uses 33 of.
+      #
+      # **One thing could make this contribute nothing, and it is worth knowing before reading a
+      # result.** The app under test is sandboxed (`App/Mimic.entitlements`), and an instrumented
+      # binary writes its `.profraw` to a path baked in at build time, under DerivedData and outside
+      # the app's container. If the sandbox refuses that write, this shard's bundle carries coverage
+      # for the *test* target and nothing for the app or the frameworks it links — which is where
+      # `AppFeatures` lives. That would show up as the merged `AppFeatures` figure sitting on 85.32%,
+      # unmoved, which is why the `coverage` job prints the unit-only table beside the merged one
+      # instead of only the number it publishes. The merge cannot make a figure *wrong* either way —
+      # a union with an empty set is the same set — so the failure mode here is "no gain", never "bad
+      # number".
       - name: Test (UI)
         env:
           ONLY_TESTING: ${{ matrix.only }}
@@ -936,6 +982,7 @@ jobs:
             test -destination 'platform=macOS' \
             $ONLY_TESTING \
             -derivedDataPath "$DERIVED_DATA" \
+            -enableCodeCoverage YES \
             -resultBundlePath "$RESULT_BUNDLE" \
             -retry-tests-on-failure -test-iterations 2 \
             CODE_SIGN_IDENTITY=- 2>&1 | tee "$BUILD_LOG"
@@ -975,6 +1022,44 @@ jobs:
             .artifacts/ui-tests-${{ matrix.id }}.log
           retention-days: 7
           if-no-files-found: ignore
+
+      # This shard's half of the merged measurement — see `Package the coverage bundle` in
+      # `macos-checks` for why the bundle travels rather than a handful of numbers, and why it is
+      # tarred first.
+      #
+      # A second upload of the same bundle on a red push to `main`, and knowingly. Folding the two
+      # together would mean one artifact serving two readers with two retentions, two conditions and
+      # two shapes — the diagnostic one is a bundle a human opens in Xcode and keeps for a week, this
+      # one is a tarball a job untars and nothing keeps. A red push to `main` is rare enough that
+      # paying for it twice is cheaper than the step that has to be right for both.
+      #
+      # **`!cancelled()` rather than no condition, and this is the asymmetry with the unit job.**
+      # `-retry-tests-on-failure` leaves this step red for a test that failed once and passed on its
+      # rerun — the workflow documents that at `Test (UI)` and it has been observed on this suite. A
+      # shard that ends red for a flake still ran everything and its bundle still holds every line
+      # those tests reached; letting that decide whether the figures are recorded would publish
+      # coverage only on the runs where no flake happened to fire.
+      - name: Package the coverage bundle
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          BUNDLE_NAME: UITests-${{ matrix.id }}.xcresult
+        run: |
+          set -euo pipefail
+          if [ ! -d ".artifacts/ui/$BUNDLE_NAME" ]; then
+            echo "::warning::No result bundle at .artifacts/ui/$BUNDLE_NAME — this shard died before xcodebuild wrote one, so the coverage job will find three bundles instead of four and publish nothing."
+            exit 0
+          fi
+          tar -C .artifacts/ui -czf ".artifacts/$BUNDLE_NAME.tar.gz" "$BUNDLE_NAME"
+          ls -lh ".artifacts/$BUNDLE_NAME.tar.gz"
+
+      - name: Upload the coverage bundle
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-bundle-ui-${{ matrix.id }}
+          path: .artifacts/UITests-${{ matrix.id }}.xcresult.tar.gz
+          retention-days: 1
+          if-no-files-found: warn
 
   # One status check standing for all three shards.
   #
@@ -1028,8 +1113,220 @@ jobs:
               ;;
           esac
 
-  # The one job in this workflow that writes to the repository. It publishes the coverage
-  # `macos-checks` measured as the two shields.io endpoint payloads README.md's badges read — the
+  # The union of what the unit suites and the window between them actually execute, which is the
+  # figure the badges publish.
+  #
+  # ## Why this is a job, and why it is not a fifth concurrent Mac
+  #
+  # It is the **fifth** macOS job in this workflow, against a concurrency this repository was
+  # observed to get four of — and it does not queue, because it never asks for a slot while the
+  # other four hold one. `needs: [macos-checks, macos-ui]` means it starts after all four have
+  # finished and released theirs. The cap in this file's header is about jobs running *at the same
+  # time*; a strictly downstream job is outside it. What it does cost is wall clock, on pushes to
+  # `main` only: a download, a merge and two `xccov` reads, after the last shard reports.
+  #
+  # It has to be a Mac. `xcrun xcresulttool` and `xcrun xccov` are Xcode, and no Xcode runs on the
+  # Linux runner — which is also why this cannot be folded into `record-coverage` below.
+  #
+  # It cannot be folded into `macos-checks` either, for a plainer reason: that job finishes around
+  # nineteen minutes and the heaviest shard around thirty-three, so anything that reads all four
+  # bundles has to start after the shards, and a step cannot wait for a job.
+  #
+  # ## Why the bundles are merged rather than the numbers
+  #
+  # Coverage is a **set union over executed lines**. A line the unit suites reach and a UI test also
+  # reaches is one covered line in the union, not two — so four sets of nine numbers cannot be
+  # combined into one set of nine by any arithmetic, because the numbers have already thrown away
+  # *which* lines. Adding them double-counts and can exceed the denominator; taking the maximum
+  # per target discards everything one suite reached that the other did not. Only the line-level data
+  # merges, and that lives in the `.xcresult`, so the four bundles travel here as tarballs and
+  # `xcresulttool merge` does the union.
+  #
+  # ## What this job will not do
+  #
+  # It will not publish a number it cannot stand behind. Two refusals, both ending in "the badges go
+  # on showing the last figures that were published":
+  #
+  #   - **Fewer bundles than `EXPECTED_COVERAGE_BUNDLES`.** A shard that died before writing one
+  #     leaves a union missing everything that shard covered, which is a *lower* number published
+  #     with no sign that anything is missing — the one outcome this whole design is against. The
+  #     count is `1 + the number of legs in macos-ui`, and it is written down here rather than
+  #     derived because a job cannot read another job's matrix; `Scripts/check_ui_shards.py` fails
+  #     the Linux job if this number and that matrix disagree, so it is checked rather than
+  #     remembered.
+  #   - **A merge that fails.** `xcresulttool merge` is the one command in this job whose behaviour
+  #     could not be checked before this landed — no Mac, no Xcode — so a future Xcode that spells it
+  #     differently must show up as a warning and a note in the summary, never as a red X on a commit
+  #     whose tests passed.
+  #
+  # Both are `continue-on-error` for that last reason, which is the rule every coverage step in this
+  # file follows: a measurement is not a verdict on a commit.
+  #
+  # ## Two tables, not one
+  #
+  # The summary carries the unit-only figures beside the merged ones, and the second is not
+  # decoration. Whether XCUITest can contribute coverage *at all* here is an open question with a
+  # specific answer waiting in it: the app under test is sandboxed, and an instrumented binary writes
+  # its `.profraw` under DerivedData, outside the app's container. If the sandbox refuses that write,
+  # the shards' bundles hold coverage for the test target and none for the app or the frameworks it
+  # links, and the merged `AppFeatures` figure comes back exactly equal to the unit-only one. Printed
+  # side by side, that reads as an answer. Printed alone, it reads as a number.
+  coverage:
+    name: Coverage (unit suites + XCUITest)
+    needs: [macos-checks, macos-ui]
+    # `!cancelled()` rather than `always()`, and the same reasoning `ui-suite` gives above: a pull
+    # request that cancelled its own jobs on a new push must not wake this one up to report on
+    # bundles nobody produced. `success()` is too strong in the other direction — a shard red on a
+    # retried flake still ran everything, and `macos-ui` rolls up to `failure` for it.
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: macos-26
+    # Download, untar, one merge, two `xccov` reads. Generous by several times over, and short enough
+    # that a wedged runner does not hold a slot for an hour.
+    timeout-minutes: 30
+
+    outputs:
+      coverage: ${{ steps.figures.outputs.json }}
+
+    env:
+      # 1 for `macos-checks` + 3 for the legs of `macos-ui`. Checked against the matrix by
+      # `Scripts/check_ui_shards.py` in the Linux job, so adding a shard and forgetting this line
+      # fails there rather than silently publishing a union with a hole in it.
+      EXPECTED_COVERAGE_BUNDLES: 4
+
+    steps:
+      # For `Scripts/update_readme_coverage.py`, which is the only thing this job runs out of the
+      # repository. No build, no test, no `macos-setup` — that action installs Tuist and generates
+      # the workspace, and nothing here compiles anything. `xcrun` finds `xccov` and `xcresulttool`
+      # in whichever Xcode the image selects by default, which is the same Xcode the four jobs
+      # upstream used, because none of them selects one either.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # `merge-multiple` flattens the four artifacts into one directory, which is what lets the step
+      # below glob for tarballs instead of naming each job's artifact — so a shard added to the
+      # matrix needs nothing changed here beyond `EXPECTED_COVERAGE_BUNDLES`.
+      #
+      # Pinned by commit like every other third-party action in this file. This workflow had never
+      # used `download-artifact` before, and two of its comments said so as a reason not to move
+      # bundles between jobs; the pin below is v7.0.0, the same major as the `upload-artifact` v7.0.1
+      # the four uploading steps use.
+      - name: Download the four result bundles
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: coverage-bundle-*
+          merge-multiple: true
+          path: .artifacts/download
+
+      # Each tarball is deleted as it is expanded. A hosted runner's disk is finite, four
+      # coverage-instrumented bundles are not small, and the merged bundle is a fifth copy of most of
+      # it — keeping the tarballs alongside all of that buys nothing, since a failure here republishes
+      # nothing rather than retrying.
+      - name: Merge the result bundles
+        id: merge
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          mkdir -p .artifacts/bundles .artifacts/merged
+
+          for tarball in .artifacts/download/*.tar.gz; do
+            [ -f "$tarball" ] || continue
+            tar -C .artifacts/bundles -xzf "$tarball" || exit 1
+            rm -f "$tarball"
+          done
+
+          found="$(find .artifacts/bundles -maxdepth 1 -name '*.xcresult' | sort)"
+          count="$(printf '%s\n' "$found" | grep -c . || true)"
+          echo "Found $count result bundle(s), expected $EXPECTED_COVERAGE_BUNDLES:"
+          printf '%s\n' "$found"
+
+          if [ "$count" -ne "$EXPECTED_COVERAGE_BUNDLES" ]; then
+            {
+              echo '### Coverage not published on this commit'
+              echo
+              echo "The merge needs $EXPECTED_COVERAGE_BUNDLES result bundles — one from the unit"
+              echo "suites and one from each UI shard — and $count arrived. A union missing a"
+              echo 'shard would publish a lower number with nothing to say a shard is missing, so'
+              echo 'nothing is published and the badges go on showing the last figures that were.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Only $count of $EXPECTED_COVERAGE_BUNDLES coverage bundles arrived — nothing published."
+            echo "state=short" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Unquoted on purpose: `$found` is newline-separated and the shell must split it into one
+          # argument per bundle. Every path in it is written by this workflow and contains no spaces.
+          # shellcheck disable=SC2086
+          if ! xcrun xcresulttool merge $found --output-path .artifacts/merged/Coverage.xcresult; then
+            {
+              echo '### Coverage not published on this commit'
+              echo
+              echo '`xcrun xcresulttool merge` failed. It is the one command in this job whose'
+              echo 'behaviour could not be checked before it landed, so this is a warning and not a'
+              echo 'red X — the badges go on showing the last figures that were published. Read the'
+              echo '`Merge the result bundles` step for what it said.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::xcresulttool merge failed — nothing published."
+            echo "state=failed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The three UI bundles are spent — the merged one holds everything they carried. The unit
+          # bundle stays, because the comparison table in the next step reads it.
+          find .artifacts/bundles -maxdepth 1 -name 'UITests-*.xcresult' -exec rm -rf {} +
+          echo "state=ready" >> "$GITHUB_OUTPUT"
+
+      # The comparison, and the reason it is here is in this job's header: the unit-only figures are
+      # what says whether XCUITest contributed anything at all. `AppFeatures` identical in the two
+      # tables means the sandbox refused the app's `.profraw` and the 158 UI tests are still invisible
+      # to the measurement — which is a finding, and one that is unreadable from the merged table on
+      # its own.
+      - name: Coverage report (unit suites only, for comparison)
+        if: steps.merge.outputs.state == 'ready'
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python3 Scripts/update_readme_coverage.py \
+            --result-bundle .artifacts/bundles/UnitTests.xcresult \
+            --title 'Code coverage — unit suites alone (the previous basis for the badges)' \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Coverage report (merged)
+        if: steps.merge.outputs.state == 'ready'
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python3 Scripts/update_readme_coverage.py \
+            --result-bundle .artifacts/merged/Coverage.xcresult \
+            --title 'Code coverage — unit suites and XCUITest, merged (what the badges publish)' \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # The nine numbers, as a job output for `record-coverage` below. A few hundred bytes, which is
+      # all that needs to reach a Linux runner — the bundles came here rather than there because
+      # merging them needs Xcode, and the merging is done.
+      #
+      # `--emit-json` refuses to write a partial table, all nine targets or none, rather than
+      # shrinking the badge's denominator into a pass. That refusal is safe to leave
+      # loud-but-not-fatal because its failure announces itself: no figures means nothing is
+      # published, and the badges go on showing the figures from the last push that did measure —
+      # visibly stale rather than quietly wrong. A silent wrong number is the outcome worth
+      # engineering against; an old one is not.
+      - name: Emit coverage figures
+        id: figures
+        if: steps.merge.outputs.state == 'ready'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 Scripts/update_readme_coverage.py \
+            --result-bundle .artifacts/merged/Coverage.xcresult \
+            --emit-json .artifacts/coverage.json
+          cat .artifacts/coverage.json
+          {
+            echo 'json<<COVERAGE_JSON_EOF'
+            cat .artifacts/coverage.json
+            echo 'COVERAGE_JSON_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  # The one job in this workflow that writes to the repository. It publishes the coverage the
+  # `coverage` job measured as the two shields.io endpoint payloads README.md's badges read — the
   # thing both badges spent this repository's whole history saying `not measured` for while the
   # number was being computed on every run and thrown away with the runner.
   #
@@ -1070,24 +1367,32 @@ jobs:
   #     payloads into the job summary *before* it tries to publish them, so a failed push leaves the
   #     figures visible on the run page rather than lost with the runner.
   #
-  # Why this is a separate job on Linux rather than three more lines on the macOS one is argued at
-  # `Emit coverage figures` above: `contents: write` must not sit on the job that compiles and runs
-  # code out of a pull request. What runs here is one stdlib Python script and some git. No build,
-  # no test, no repository code executes.
+  # Why this is a separate job on Linux rather than three more lines on the `coverage` job above:
+  # `contents: write` must not sit on a job that runs on the same runner image as the ones
+  # compiling code out of a pull request, and the merged bundles have no reason to be near a write
+  # token. What runs here is one stdlib Python script and some git. No build, no test, no
+  # repository code executes.
   #
-  # **`needs: macos-checks`, not the UI shards, and that is now structural rather than a workaround.**
-  # It used to say `needs: macos` with `always()`, because coverage is measured two steps before
-  # XCUITest started and this repository's UI suite is documented as ending red on a test that passed
-  # on its retry — letting that decide whether the number is recorded would mean the README updates
-  # only on runs where a flake happened not to fire. Splitting the UI suite into its own job says the
-  # same thing in the dependency graph instead of in an `always()`: the job that measures coverage is
-  # the job this one waits for, and the shards are simply not upstream of it. `always()` is kept for
-  # the remaining case it covers — a `macos-checks` that died *before* the measurement leaves the
-  # output empty, which the first step below reports and stops on, rather than skipping this job with
-  # no explanation.
+  # **`needs: coverage`, and the shards are upstream of it now.** This used to say `needs:
+  # macos-checks` and argue, at length, that the UI shards must *not* be upstream: coverage was
+  # measured two steps before XCUITest started, and this repository's UI suite is documented as
+  # ending red on a test that passed on its retry, so letting that decide whether the number is
+  # recorded would mean the badges updating only on runs where a flake happened not to fire.
+  #
+  # The first half of that no longer holds — the measurement is the union of the unit bundle and the
+  # three shards', so the shards are upstream of it by construction. The second half still does, and
+  # it moved rather than went away: the `coverage` job takes `!cancelled()` instead of `success()`,
+  # and each shard uploads its bundle under `!cancelled()` too, so a shard red for a flake still
+  # contributes everything it covered. What is *not* tolerated is a shard that produced no bundle at
+  # all — that job counts and refuses. The flake argument is answered by the condition, not by
+  # cutting the shards out of the graph.
+  #
+  # `always()` is kept for the case it always covered — a `coverage` job that died before emitting
+  # leaves the output empty, which the first step below reports and stops on, rather than skipping
+  # this job with no explanation.
   record-coverage:
     name: Publish coverage badges
-    needs: macos-checks
+    needs: coverage
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
@@ -1109,11 +1414,11 @@ jobs:
       - name: Write the figures out
         id: figures
         env:
-          COVERAGE_JSON: ${{ needs.macos-checks.outputs.coverage }}
+          COVERAGE_JSON: ${{ needs.coverage.outputs.coverage }}
         run: |
           set -euo pipefail
           if [ -z "${COVERAGE_JSON:-}" ]; then
-            echo "No coverage figures in this run: the macOS job did not reach the measurement."
+            echo "No coverage figures in this run: the coverage job did not reach the measurement."
             echo "state=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -287,11 +287,27 @@ python3 Scripts/check_doc_counts.py    # recount every number above, and catch a
 
 ### Coverage
 
-**Coverage is measured on every CI run**, by the macOS job running the unit suites with
-`-enableCodeCoverage YES` — XCUITest and the Linux suites excepted, and no floor enforced against
-the figures. **The two badges above are live**: every push to `main` publishes them to an orphan
-`badges` branch as shields.io endpoint payloads, so nothing in the tree changes when they move. The
-detailed per-target block below is the other half, and it is deliberately local-only —
+**Coverage is measured on every CI run**, with `-enableCodeCoverage YES` on the unit suites and on
+all three XCUITest shards. No floor is enforced against the figures.
+
+**The badges are the union of the four**, not a sum. Coverage is a set over executed lines, so four
+sets of per-target numbers cannot be added — a line two suites both reach is one covered line. The
+four result bundles are merged with `xcrun xcresulttool merge` and read once, which is what the
+`Coverage (unit suites + XCUITest)` job does on every push to `main` before the figures are
+published to an orphan `badges` branch as shields.io endpoint payloads. Nothing in the tree changes
+when they move.
+
+That merge is why the numbers moved. Until it existed the badges came from a run passing
+`-skip-testing:MimicUITests`, so all 158 UI tests — the only ones that touch the SwiftUI layer —
+contributed nothing to the published figure for how well this window is tested.
+
+Two things the badges are not. The first reads `Mimic.app coverage`, and `Mimic.app` is the app
+bundle *target*: `App/Sources/MimicApp.swift`, 34 lines, the `@main` entry point. The application
+itself is `AppFeatures`, which the second badge counts among its eight modules. And a run that
+publishes nothing leaves both showing the last figures that did publish — deliberately, since a
+stale number is recoverable and a quietly wrong one is not.
+
+The detailed per-target block below is the other half, and it is deliberately local-only —
 `./Scripts/run_full_test_suite.sh` on a Mac is its only writer, so it is as fresh as the last full
 run somebody did by hand.
 
@@ -299,10 +315,13 @@ run somebody did by hand.
 <!-- coverage:generated:end -->
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and every push to
-`main`, in seven jobs across five definitions, finishing in about **30 minutes**: Linux builds
+`main`, in eight jobs across six definitions, finishing in about **30 minutes**: Linux builds
 `Package.swift`, the portable suites and every gate needing no toolchain in a couple of minutes;
 macOS does `tuist generate`, the Debug build, the measured app suites, the CLI end-to-end check and
-the Release gate, with the XCUITest suite beside it in three shards on three runners. Both runners
+the Release gate, with the XCUITest suite beside it in three shards on three runners. Four of those
+eight run at once, which is the concurrent-macOS-job limit this repository was measured to get; the
+coverage merge is a fifth macOS job and adds no queue, because it starts only once all four have
+finished — and only on a push to `main`, so a pull request's 30 minutes is untouched. Both runners
 are free on a public repository. Why the work divides that way, and what each gate settles, is in
 [`ci.md`](.agents/skills/mimic-build-and-test/references/ci.md).
 

--- a/Scripts/check_ui_shards.py
+++ b/Scripts/check_ui_shards.py
@@ -31,7 +31,15 @@ So the shard list is checked against the tree rather than trusted:
     were chosen for is wrong by that much;
   - a shard naming a class that **does not exist** fails, which is what a rename leaves behind —
     `xcodebuild` reports it as "no tests to run" and exits 0, so the shard goes green having run
-    nothing.
+    nothing;
+  - and `EXPECTED_COVERAGE_BUNDLES` in the same workflow disagreeing with the shard count fails,
+    which is the same shape one level up. The `coverage` job merges one result bundle per test-running
+    job — the unit suites plus every shard — and refuses to publish if fewer arrive than it expects.
+    It cannot count the shards for itself: a job cannot read another job's `matrix`, so the total is
+    written down as a literal. Add a fourth shard and leave the literal at 4 and that job merges
+    three shards' worth of coverage while believing it has all of them, publishing a number lower
+    than the truth with nothing anywhere to say a shard is missing. Lower the literal and the job
+    refuses forever. Both are quiet; this makes them loud.
 
 It reads the workflow as text and the suites as text. Nothing here imports PyYAML: the Linux CI job
 installs `python3-minimal` and has no third-party packages at all, which is a constraint every
@@ -58,6 +66,14 @@ UI_TESTS = ROOT / "MimicUITests"
 TARGET = "MimicUITests"
 
 ONLY_TESTING = re.compile(r"-only-testing:" + TARGET + r"/([A-Za-z_][A-Za-z0-9_]*)")
+
+# The literal the `coverage` job compares its downloaded bundle count against. Matched as an `env:`
+# entry rather than parsed as YAML, for the reason the module header gives: nothing here imports
+# PyYAML.
+EXPECTED_BUNDLES = re.compile(r"^\s*EXPECTED_COVERAGE_BUNDLES:\s*(\d+)\s*$", re.MULTILINE)
+
+# A shard is a `- id: N` entry, and its flags are the `-only-testing:` lines before the next one.
+SHARD_SPLIT = r"^\s*- id:\s*"
 
 # A class declaration at the start of a line, with a superclass. Page objects in this target are
 # `struct`s and are correctly invisible to this; a `class` with no superclass is not an XCTestCase
@@ -100,11 +116,54 @@ def suite_classes(sources):
     return {name: n for name, n in counts.items() if n > 0}
 
 
+def shard_blocks(workflow_text):
+    """`[(id, [class names])]` for every matrix leg that names at least one class.
+
+    A leg naming none is not a shard — it is a `- id:` in some other list, or a leg mid-edit — and
+    counting it would make the bundle-count check below disagree with what the `coverage` job will
+    actually be handed.
+    """
+    blocks = re.split(SHARD_SPLIT, workflow_text, flags=re.MULTILINE)[1:]
+    found = []
+    for block in blocks:
+        names = ONLY_TESTING.findall(block)
+        if names:
+            found.append((block.split("\n", 1)[0].strip(), names))
+    return found
+
+
+def check_bundle_count(workflow_text):
+    """`EXPECTED_COVERAGE_BUNDLES` against the shard count. One string, or none."""
+    shards = len(shard_blocks(workflow_text))
+    declared = EXPECTED_BUNDLES.search(workflow_text)
+
+    if declared is None:
+        return [
+            "no `EXPECTED_COVERAGE_BUNDLES:` in .github/workflows/ci.yml. The `coverage` job needs "
+            "it to know how many result bundles a complete merge has — one from the unit suites and "
+            f"one from each of the {shards} shards, so {shards + 1}. If the coverage job is gone, "
+            "delete this check with it rather than leaving a checker that compares nothing."
+        ]
+
+    expected = shards + 1
+    if int(declared.group(1)) != expected:
+        return [
+            f"EXPECTED_COVERAGE_BUNDLES is {declared.group(1)} in .github/workflows/ci.yml and the "
+            f"`macos-ui` matrix has {shards} shard(s), so a complete merge has {expected} bundles — "
+            f"one from the unit suites and one per shard. Too high and the `coverage` job refuses "
+            f"to publish on every run; too low and it merges fewer shards than exist while "
+            f"believing it has them all, publishing a figure lower than the truth with nothing to "
+            f"say a shard is missing."
+        ]
+
+    return []
+
+
 def check(workflow_text, sources):
     """Returns `(problems, sharded, tests)` — a list of strings, the shard list, the counts."""
     sharded = shard_classes(workflow_text)
     tests = suite_classes(sources)
-    problems = []
+    problems = list(check_bundle_count(workflow_text))
 
     seen = set()
     for name in sharded:
@@ -138,17 +197,10 @@ def report_balance(workflow_text, tests):
     Test count is a proxy for time and the workflow says so; a spread this prints is a prompt to go
     and look at the real per-test durations in a shard's result bundle, not a verdict on anything.
     """
-    # A shard is a `- id: N` entry, and its flags are the `-only-testing:` lines before the next one.
-    blocks = re.split(r"^\s*- id:\s*", workflow_text, flags=re.MULTILINE)[1:]
-    if not blocks:
-        return
-    totals = []
-    for block in blocks:
-        shard_id = block.split("\n", 1)[0].strip()
-        names = ONLY_TESTING.findall(block)
-        if not names:
-            continue
-        totals.append((shard_id, sum(tests.get(n, 0) for n in names), names))
+    totals = [
+        (shard_id, sum(tests.get(n, 0) for n in names), names)
+        for shard_id, names in shard_blocks(workflow_text)
+    ]
     if not totals:
         return
 
@@ -181,6 +233,10 @@ GOOD_WORKFLOW = """
           - id: 2
             only: >-
               -only-testing:MimicUITests/GammaUITests
+
+  coverage:
+    env:
+      EXPECTED_COVERAGE_BUNDLES: 3
 """
 
 GOOD_SOURCES = [
@@ -250,8 +306,52 @@ def self_test():
     # A workflow that has stopped naming any class at all. Every class is then unsharded, which is
     # the loud version of the quiet failure — worth pinning, because a checker that reported "all
     # clear" against an empty flag list would be agreeing with nothing.
-    problems, _s, _t = check("matrix:\n  include: []\n", GOOD_SOURCES)
+    problems, _s, _t = check(
+        "matrix:\n  include: []\nEXPECTED_COVERAGE_BUNDLES: 1\n", GOOD_SOURCES
+    )
     expect("an empty shard list fails for every class", len(problems) == 3, problems)
+
+    # The bundle-count check, driven on its own so a failure names it rather than showing up as a
+    # count that moved. Two shards in the fixture, so a complete merge is three bundles.
+    expect(
+        "a bundle count matching the shards passes",
+        check_bundle_count(GOOD_WORKFLOW) == [],
+        check_bundle_count(GOOD_WORKFLOW),
+    )
+    too_low = GOOD_WORKFLOW.replace("EXPECTED_COVERAGE_BUNDLES: 3", "EXPECTED_COVERAGE_BUNDLES: 2")
+    problems = check_bundle_count(too_low)
+    expect(
+        "a bundle count below the shard count fails",
+        len(problems) == 1 and "lower than the truth" in problems[0],
+        problems,
+    )
+    too_high = GOOD_WORKFLOW.replace("EXPECTED_COVERAGE_BUNDLES: 3", "EXPECTED_COVERAGE_BUNDLES: 9")
+    problems = check_bundle_count(too_high)
+    expect(
+        "a bundle count above the shard count fails",
+        len(problems) == 1 and "refuses to publish" in problems[0],
+        problems,
+    )
+    missing = GOOD_WORKFLOW.replace("      EXPECTED_COVERAGE_BUNDLES: 3\n", "")
+    problems = check_bundle_count(missing)
+    expect(
+        "a workflow with no bundle count at all fails",
+        len(problems) == 1 and "no `EXPECTED_COVERAGE_BUNDLES:`" in problems[0],
+        problems,
+    )
+    # A third shard added to the matrix and the literal left where it was — the drift this check
+    # exists for, and the one that would otherwise publish a figure lower than the truth in silence.
+    grown = GOOD_WORKFLOW.replace(
+        "  coverage:",
+        "          - id: 3\n            only: >-\n"
+        "              -only-testing:MimicUITests/DeltaUITests\n\n  coverage:",
+    )
+    problems = check_bundle_count(grown)
+    expect(
+        "adding a shard without moving the bundle count fails",
+        len(problems) == 1 and "3 shard(s)" in problems[0],
+        problems,
+    )
 
     if failures:
         print(f"\n{len(failures)} self-test failure(s). The checker is not trustworthy — fix it "


### PR DESCRIPTION
## What this fixes

The badges published `Mimic.app coverage 46.67%` and `modules at or above 95% 5/8`, with `AppFeatures` — the 14,990-line SwiftUI and workflow layer — measured at **85.32%**.

They were produced by a step passing `-skip-testing:MimicUITests`. So all **158 XCUITest cases**, the only tests in this repository that touch that layer, contributed **nothing** to the number published about how well this window is tested.

Per-target figures from run #96, for the record:

| Target | Covered / executable | % |
|---|---|---|
| Mimic.app | 28 / 60 | 46.67% |
| Domain | 2298 / 2390 | 96.15% |
| MockServerEngine | 341 / 352 | 96.88% |
| Persistence | 992 / 1011 | 98.12% |
| DesignSystem | 2440 / 2512 | 97.13% |
| SpecImport | 1087 / 1119 | 97.14% |
| ControlPlane | 350 / 413 | 84.75% |
| MimicCLICore | 1260 / 1453 | 86.72% |
| AppFeatures | 15199 / 17814 | 85.32% |

## Why the bundles are merged rather than the numbers

**Coverage is a set union over executed lines, not a sum.** A line the unit suites reach and a UI test also reaches is one covered line in the union, not two.

Four sets of nine per-target numbers therefore cannot be combined into one set of nine by any arithmetic — the numbers have already thrown away *which* lines. Adding double-counts and can exceed the denominator; taking the per-target maximum discards everything one suite reached that the other did not. Only the line-level data merges, and that lives in the `.xcresult`.

So the bundles travel, as `.tar.gz` — a bundle is thousands of small files and `upload-artifact` posts each one, which turns a directory upload into a step measured in tens of minutes — and `xcrun xcresulttool merge` does the union. `Scripts/update_readme_coverage.py` reads the merged bundle exactly as it read the single one, unchanged.

This reverses the argument the old `Emit coverage figures` step made for handing nine numbers across as a job output. That comment was right about the cost of moving bundles and wrong about the requirement; the workflow now records both halves of that.

## The changes

- The three `macos-ui` shards pass `-enableCodeCoverage YES` — on **every** run, not only the ones that publish. What CI measures should be what CI ran, and a flag set on `main` and clear on pull requests is one whose effect on this suite nobody sees until it is too late to attribute.
- A new **`coverage`** job merges the four bundles and emits the figures. `record-coverage` takes them from there instead of from `macos-checks`.
- Each of the four test-running jobs tars and uploads its bundle, on pushes to `main` only.

### It is a fifth macOS job and does not queue

Run #89 measured the concurrent-macOS-job limit on this repository at **four**, against a documented five, and the workflow is designed around that. This job declares `needs: [macos-checks, macos-ui]`, so it starts only once all four have finished and returned their slots — it asks for a slot that is free by construction.

The rule the header was really stating is now spelled that way: a fifth *concurrent* macOS job queues for about the length of a shard; a fifth job *downstream* of the other four does not. The question to ask of a new macOS job is not "is it the fifth" but "does it run beside the other four or after them".

It runs on pushes to `main` only, so a pull request's ~30 minutes is untouched.

## What it refuses to publish

Two refusals, both ending in "the badges go on showing the last figures that were published":

- **Fewer bundles than `EXPECTED_COVERAGE_BUNDLES`.** A shard that died before writing one leaves a union missing everything that shard covered — a *lower* number, published with nothing anywhere to say something is missing. That is the outcome this whole design is against.
- **A merge that fails.** `xcresulttool merge` is the one command in the job whose behaviour could not be checked before it landed, so a future Xcode that spells it differently is a warning and a note in the summary, never a red X on a commit whose tests passed.

`EXPECTED_COVERAGE_BUNDLES` cannot be derived — a job cannot read another job's `matrix` — so it is a literal, and `Scripts/check_ui_shards.py` gains a **fourth verdict** that fails the Linux job when it and the shard count disagree. Add a fourth shard and leave the literal at 4 and the coverage job merges three shards' worth believing it has all of them. Its self-test covers too low, too high, missing entirely, and a shard added without moving it, over a workflow and a suite tree written out in the file. Verified as a negative control against the real workflow: setting the literal to 5 turns the checker red.

## One thing could make this contribute nothing, and the job says so rather than hiding it

The app under test is sandboxed (`App/Mimic.entitlements`), and an instrumented binary writes its `.profraw` to a path baked in at build time — under DerivedData, outside the app's container. If the sandbox refuses that write, the shards' bundles carry coverage for the test target and none for the app or the frameworks it links, which is where `AppFeatures` lives.

That is why the summary prints **two tables**: the unit-only figures beside the merged ones. `AppFeatures` identical in both means the UI suite is still invisible to the measurement, and the next move is the app's entitlements in CI rather than anything in this pipeline. Printed side by side that reads as an answer; printed alone it reads as a number.

A union with an empty set is the same set, so the failure mode here is **"no gain", never a wrong number**.

## Branch protection

The required checks are now `Build and test (Linux)`, `Build, unit suites, Release, CLI e2e (macOS)` and `UI suite`; the workflow comment and `ci.md` record that, replacing the note asking whoever merged #57 to update them.

Neither coverage job belongs in that list, and the docs now say why: they run only on pushes to `main`, so on a pull request they never report — and a required check that never reports blocks the merge forever.

## Verification

Run in this container, all green:

```
check_doc_counts.py --self-test / check_doc_counts.py
check_module_edges.py
check_compiler_settings.py
check_lockfiles.py
check_skills.py
update_readme_coverage.py --self-test
check_house_rules.sh --self-test / check_house_rules.sh
check_ui_shards.py --self-test / check_ui_shards.py
```

Plus: the workflow parses under a duplicate-key-strict YAML loader, the job graph resolves (six definitions, eight jobs, every `needs:` naming a real job, the output reference resolving), every `run:` block passes `bash -n`, no GitHub expression is interpolated into any `run:` block, and no tabs.

**Not verified here, and I am not claiming otherwise:** this container has no Swift toolchain and no Xcode, so nothing Swift was built or run. `xcrun xcresulttool merge`, and whether the sandbox permits the app's `.profraw`, are what the first run on `main` settles — the merged table beside the unit-only one is how you read the answer.

`actions/download-artifact` is new to this workflow and pinned by commit like everything else: `37930b1c2abaa49bbe596cd826c3c89aef350131` (v7.0.0), the same major as the `upload-artifact` v7.0.1 already in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SpJbSWRnbQwtCexsZjpNz


---
_Generated by [Claude Code](https://claude.ai/code/session_012SpJbSWRnbQwtCexsZjpNz)_