### PR TITLE
Fix the capture-submenu flake, and make the first badge report coverage

### DIFF
--- a/.agents/skills/mimic-ui-tests/references/accessibility-tree.md
+++ b/.agents/skills/mimic-ui-tests/references/accessibility-tree.md
@@ -85,3 +85,40 @@ Use a **behavioural read-back** instead: click, type, then assert the field hold
 that the sheet opened, or that the crumb appeared. That catches what the gate was reaching for — a
 click landing on whatever happens to be at that point when the card is below the fold — and it
 catches it at the click rather than three assertions later as "the value never committed".
+
+## `waitForExistence` is not "it has stopped moving", and a click computes a frame
+
+This is the rule behind the longest-running flake in the suite, and the first two attempts to fix it
+were both wrong in the same way.
+
+`waitForExistence` returns when an element enters the accessibility tree. For an AppKit menu that
+happens when the menu is **created** — before it is positioned, and while it is still fading in.
+`click()` then resolves the element again, takes the frame from that snapshot, and synthesizes an
+event at its centre. If the frame is a moment stale, the click lands on the menu's backdrop, the menu
+closes, and **nothing happens at all**. The only evidence is the absence of whatever the item was
+supposed to produce, which is indistinguishable from the app failing to produce it.
+
+The same applies outside menus, to anything the window is animating. Selecting a request log row
+opens the inspector inside `withAnimation(DSAnimation.drawerToggle)`, which narrows the drawer
+underneath it and moves every row — so a ⌘-click aimed at the next row can land between two rows and
+select nothing, and it presents as the modifier having been dropped rather than as a moved target.
+
+**What went wrong twice.** `testAddingRequestsToAnExistingJourneyFromTheLog` failed waiting five
+seconds for the capture sheet on run #91 and passed on the retry, so the wait was widened to fifteen
+under a comment explaining that the machine had been busy. Run #98 failed at that same line **twice
+in one run** at fifteen seconds. A sheet that is merely slow arrives inside fifteen seconds; the
+clock was never the variable. Widening a timeout is what you do when something arrives late — not
+when it never arrives.
+
+**What to do instead.** `UITestApp.waitForStableFrame(_:)` polls until an element reports the same
+non-empty frame twice, which is the cheapest available statement of "it has stopped". Call it before
+any click aimed at something that has just appeared or is being animated. For a nested menu — a
+submenu parent, then a child — use `UITestApp.chooseFromSubmenu(in:parent:item:thenAwait:…)`, which
+settles both levels, and re-opens the whole menu and tries again if the outcome never comes.
+
+Two properties of that helper worth keeping if it is ever rewritten. It takes the **outcome** as an
+argument and every attempt ends waiting for it, so a broken app still fails — the retry removes a
+lost click, not a missing sheet. And a retry is recorded with `XCTContext.runActivity`, because it
+cannot tell a missed click apart from an app that intermittently fails to present, and the result
+bundle is the only place that distinction can be recovered. `print()` is no use for this: runner
+output never reaches the xcodebuild log CI reads.

--- a/MimicUITests/AppLaunchSupport.swift
+++ b/MimicUITests/AppLaunchSupport.swift
@@ -82,6 +82,134 @@ enum UITestApp {
         waitUntil(timeout: timeout) { elements.contains { $0.exists } }
     }
 
+    // MARK: - Menus
+
+    /// Waits until `element` reports the same non-empty frame twice in a row.
+    ///
+    /// `waitForExistence` answers "is it in the accessibility tree", which for an AppKit menu happens
+    /// when the menu is *created* — before it has been positioned and while it is still fading in. A
+    /// `click()` in that window computes a frame that is about to change and synthesizes the event at
+    /// coordinates the item has already left, so the click lands on the menu's backdrop, the menu
+    /// closes, and nothing happens. Nothing about that reads as a missed click afterwards: the test
+    /// simply waits out its timeout for a sheet nobody asked for.
+    ///
+    /// Two equal readings a poll apart is the cheapest statement of "it has stopped moving". It is a
+    /// heuristic and worth naming as one — a frame that pauses mid-animation for a whole poll would
+    /// satisfy it — but it is a far better one than a fixed pause, which this file may not use and
+    /// would be wrong in both directions anyway.
+    ///
+    /// `snapshot()` rather than `.frame`: reading `.frame` on an element that has just gone away
+    /// raises an XCTest failure, and every suite here runs with `continueAfterFailure = false`, so a
+    /// menu that closed underneath this helper would end the test rather than let the caller retry.
+    /// `try?` turns that into "no reading yet".
+    @MainActor
+    static func waitForStableFrame(_ element: XCUIElement, timeout: TimeInterval = 2) {
+        var previous: CGRect?
+        _ = waitUntil(timeout: timeout, pollInterval: 0.1) {
+            let current = (try? element.snapshot())?.frame
+            defer { previous = current }
+            guard let current, current.width > 0, current.height > 0 else { return false }
+            return current == previous
+        }
+    }
+
+    /// Closes whatever menu is open, including a submenu, and returns once none is.
+    ///
+    /// `app.menus` counts open `AXMenu` elements and does not include the menu bar, so this is "is a
+    /// menu on screen" rather than "does the app have menus". One Escape closes one level, which is
+    /// why this loops.
+    @MainActor
+    static func dismissAnyOpenMenu(in app: XCUIApplication, levels: Int = 3) {
+        for _ in 0..<levels {
+            guard app.menus.count > 0 else { return }
+            app.typeKey(.escape, modifierFlags: [])
+            _ = waitUntil(timeout: 1) { app.menus.count == 0 }
+        }
+    }
+
+    /// Opens a submenu, picks `item` out of it, and returns once `outcome` is on screen.
+    ///
+    /// The one interaction in this suite that has flaked in two different tests, and the reason it
+    /// is a helper rather than eight lines written twice.
+    ///
+    /// **What goes wrong.** Driving a nested AppKit menu means clicking a submenu parent, waiting for
+    /// a child that exists before it is placed, and clicking that. Two frames have to be right and
+    /// both are computed from a snapshot taken a moment earlier. When one is not, the menu closes
+    /// having done nothing — and the only evidence is the *absence* of whatever the item was supposed
+    /// to produce, which is indistinguishable from the app failing to produce it.
+    ///
+    /// `RequestLogUITests.testAddingRequestsToAnExistingJourneyFromTheLog` failed exactly that way on
+    /// run #91 with a five-second wait for the sheet, and the fix applied then was to widen the wait
+    /// to fifteen. **Run #98 failed at the same line, twice in the same run, at fifteen.** A sheet
+    /// that is merely slow arrives inside fifteen seconds; one that never arrives is a different
+    /// failure, and widening the clock was the wrong reading of the first one. That is what this
+    /// replaces.
+    ///
+    /// **What it does.** Waits for each menu level to stop moving before clicking it, and if the
+    /// outcome still does not arrive, dismisses whatever is left open and drives the whole
+    /// interaction again — up to `attempts` times. Only the last attempt gets the full
+    /// `outcomeTimeout`; the earlier ones get a short one, so a genuinely slow outcome is still
+    /// waited out properly while a missed click is discovered quickly instead of costing the caller
+    /// three long waits.
+    ///
+    /// **What it does not do, and this is the part worth being honest about.** A retry cannot tell a
+    /// missed click apart from an app that intermittently fails to present. If the product is the
+    /// flaky half, this hides it up to `attempts` times — so each re-open is recorded as an activity
+    /// in the result bundle, and a caller that cares can compare. What it cannot do is turn a broken
+    /// app green: every attempt ends in the same wait for the same `outcome`, so a sheet that never
+    /// comes still fails, with the caller's own message.
+    ///
+    /// Returns whether `outcome` ever appeared, so the caller asserts with its own wording.
+    @MainActor
+    @discardableResult
+    static func chooseFromSubmenu(
+        in app: XCUIApplication,
+        parent: XCUIElement,
+        item: XCUIElement,
+        thenAwait outcome: XCUIElement,
+        // `@MainActor` on the closure type, not decoration: callers build it out of their own
+        // `@MainActor` row helpers, and a plain `() -> Void` cannot call one synchronously under
+        // Swift 6 isolation checking.
+        reopenMenu: @MainActor () -> Void,
+        menuIsAlreadyOpen: Bool = false,
+        attempts: Int = 3,
+        menuTimeout: TimeInterval = 5,
+        outcomeTimeout: TimeInterval = 15
+    ) -> Bool {
+        let rounds = max(1, attempts)
+        for attempt in 1...rounds {
+            if attempt > 1 || !menuIsAlreadyOpen {
+                if attempt > 1 {
+                    // A marker with an empty body, and the only trace a retry leaves. It lands in the
+                    // result bundle, which is uploaded on a red run — so "this passed, but only on
+                    // the second open" is answerable rather than invisible. `print()` would not do:
+                    // runner output never reaches the xcodebuild log this workflow reads.
+                    XCTContext.runActivity(
+                        named: "Re-opened the submenu (attempt \(attempt) of \(rounds))"
+                    ) { _ in }
+                }
+                dismissAnyOpenMenu(in: app)
+                reopenMenu()
+            }
+
+            guard parent.waitForExistence(timeout: menuTimeout) else { continue }
+            waitForStableFrame(parent)
+            parent.click()
+
+            guard item.waitForExistence(timeout: menuTimeout) else { continue }
+            waitForStableFrame(item)
+            item.click()
+
+            // The full clock only on the way out. An intermediate attempt that waits fifteen seconds
+            // for something a missed click means will never come turns a three-attempt helper into a
+            // forty-five-second one, on a test that already runs past a minute.
+            let isLastAttempt = attempt == rounds
+            let wait = isLastAttempt ? outcomeTimeout : min(outcomeTimeout, 4)
+            if outcome.waitForExistence(timeout: wait) { return true }
+        }
+        return false
+    }
+
     static var launchedApps: [NSRunningApplication] {
         NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
     }

--- a/MimicUITests/MimicUITests.swift
+++ b/MimicUITests/MimicUITests.swift
@@ -1355,6 +1355,12 @@ final class MimicUITests: XCTestCase {
         let captureMenu = app.menuItems["Add 2 requests to journey"]
         let collapsedMenu = app.menuItems["Add to journey"]
         firstRow.click()
+        // Selecting the first row opens the inspector with an animation, and the drawer narrows
+        // underneath it while that runs. The ⌘-click and the right-click below are both aimed at a
+        // frame, so they race it — and a ⌘-click that lands between two rows leaves the selection at
+        // one, which presents here as the modifier having been dropped. It is not; the row moved.
+        UITestApp.waitForStableFrame(secondRow)
+
         XCUIElement.perform(withKeyModifiers: .command) {
             secondRow.click()
         }
@@ -1375,20 +1381,27 @@ final class MimicUITests: XCTestCase {
                     + "visibleMenuItems=\(visible)"
             )
         }
-        captureMenu.click()
-
-        let newJourneyItem = app.menuItems["New journey from these 2 requests\u{2026}"]
-        XCTAssertTrue(
-            newJourneyItem.waitForExistence(timeout: 5),
-            "The submenu should offer a new journey for the selection"
+        // The ellipsis promises a dialog, and now there is one. Driven through the shared helper
+        // rather than clicked here: this is the nested-menu interaction that has flaked in two
+        // different suites, and `UITestApp.chooseFromSubmenu` carries the account of why widening the
+        // wait was the wrong fix for it. The assertion is unchanged — every attempt ends waiting for
+        // this same field.
+        let sheetAppeared = UITestApp.chooseFromSubmenu(
+            in: app,
+            parent: captureMenu,
+            item: app.menuItems["New journey from these 2 requests\u{2026}"],
+            thenAwait: captureSheet.nameField,
+            reopenMenu: { secondRow.rightClick() },
+            menuIsAlreadyOpen: true
         )
-        newJourneyItem.click()
-
-        // The ellipsis promises a dialog, and now there is one.
-        XCTAssertTrue(
-            captureSheet.nameField.waitForExistence(timeout: 5),
-            "Capturing into a new journey should ask for a name first"
-        )
+        if !sheetAppeared {
+            let visible = app.menuItems.allElementsBoundByIndex.prefix(8).map(\.title)
+            XCTFail(
+                "Capturing into a new journey should ask for a name first. "
+                    + "openMenus=\(app.menus.count) visibleMenuItems=\(visible) "
+                    + "journeyEditorOpen=\(app.staticTexts["journeyEditor.name"].exists)"
+            )
+        }
         captureSheet.nameField.click()
         captureSheet.nameField.typeKey("a", modifierFlags: .command)
         captureSheet.nameField.typeText("Captured session")

--- a/MimicUITests/RequestLogUITests.swift
+++ b/MimicUITests/RequestLogUITests.swift
@@ -1007,6 +1007,14 @@ final class RequestLogUITests: MimicUITestCase {
         // Two rows selected, then a right-click on the third — which is *outside* the selection, so
         // the menu must act on the clicked row alone rather than on rows the pointer is nowhere near.
         logRow(identifiers[0]).click()
+        // Selecting a row opens the inspector, and `WorkspaceView` opens it inside
+        // `withAnimation(DSAnimation.drawerToggle)` — so the drawer beneath it narrows while that
+        // runs and every row moves. The two clicks below are aimed at a frame, which makes them a
+        // race against that animation: a ⌘-click landing between two rows selects nothing, and a
+        // right-click landing on a row that *is* in the selection opens the plural menu, which is
+        // the assertion four lines down. Waiting for the row to stop moving removes both.
+        UITestApp.waitForStableFrame(logRow(identifiers[2]))
+
         XCUIElement.perform(withKeyModifiers: .command) {
             logRow(identifiers[1]).click()
         }
@@ -1022,27 +1030,37 @@ final class RequestLogUITests: MimicUITestCase {
             "The menu must not act on a selection the clicked row is not part of"
         )
 
-        singularMenu.click()
-        let newJourneyItem = app.menuItems["New journey from this request\u{2026}"]
-        XCTAssertTrue(
-            newJourneyItem.waitForExistence(timeout: 5),
-            "The submenu should offer a new journey for the single request"
-        )
-        newJourneyItem.click()
-
-        // Fifteen seconds, not five, and this is the one wait in the file that needs them. Everything
-        // else here waits for an element that is already being drawn; this one waits for AppKit to
-        // tear down a *nested* menu and for SwiftUI to then present a sheet, two animations in series
-        // with a run loop handover between them. Run #91 spent longer than five seconds on exactly
-        // that and failed here — then passed on the retry, which is what says the sheet was coming
-        // and the clock was short rather than the capture being broken.
+        // The nested menu is driven through the shared helper rather than clicked here, and the
+        // history is why. This line failed on run #91 waiting five seconds for the sheet; the reading
+        // then was "the machine was busy and the clock was short", and the wait was widened to
+        // fifteen. **Run #98 failed here twice in the same run, at fifteen.** A sheet that is merely
+        // slow arrives inside fifteen seconds. One that never arrives is a different failure, and the
+        // clock was never the thing to change — `UITestApp.chooseFromSubmenu` carries the account.
         //
-        // Not a weakened assertion. A sheet that never appears still fails, and fails with this same
-        // message; the only thing the longer clock buys is not failing a machine that was busy.
-        XCTAssertTrue(
-            captureSheet.nameField.waitForExistence(timeout: 15),
-            "Capturing into a new journey should ask for a name first"
+        // Not a weakened assertion, and this matters more than it did before: every attempt the
+        // helper makes ends waiting for this same field, so a capture that does not present still
+        // fails here. What the helper removes is the *click* being lost, not the sheet being absent.
+        let sheetAppeared = UITestApp.chooseFromSubmenu(
+            in: app,
+            parent: singularMenu,
+            item: app.menuItems["New journey from this request\u{2026}"],
+            thenAwait: captureSheet.nameField,
+            reopenMenu: { self.logRow(identifiers[2]).rightClick() },
+            menuIsAlreadyOpen: true
         )
+        if !sheetAppeared {
+            // Named rather than asserted, in the style this suite already uses for the capture menu:
+            // the three states below are three different bugs and the message has to say which.
+            // `journeyEditorOpen` is the discriminator worth having — a journey that exists without
+            // the sheet ever appearing means the menu item's action *ran* and the presentation was
+            // dropped, which is the app's fault and not the click's.
+            let visible = app.menuItems.allElementsBoundByIndex.prefix(8).map(\.title)
+            XCTFail(
+                "Capturing into a new journey should ask for a name first. "
+                    + "openMenus=\(app.menus.count) visibleMenuItems=\(visible) "
+                    + "journeyEditorOpen=\(app.staticTexts["journeyEditor.name"].exists)"
+            )
+        }
         captureSheet.nameField.click()
         captureSheet.nameField.typeKey("a", modifierFlags: .command)
         captureSheet.nameField.typeText("Checkout")
@@ -1064,22 +1082,28 @@ final class RequestLogUITests: MimicUITestCase {
         // Now the half nothing covered: appending to a journey that already exists, chosen by name
         // from the submenu.
         logRow(identifiers[0]).click()
-        logRow(identifiers[0]).rightClick()
+        UITestApp.waitForStableFrame(logRow(identifiers[0]))
+
+        // The same nested menu as above, so the same helper. There is no sheet on this path — the
+        // journey already exists and picking it by name appends straight away — so the outcome
+        // waited for is the second step appearing in the editor.
         let appendMenu = app.menuItems["Add to journey"]
-        XCTAssertTrue(appendMenu.waitForExistence(timeout: 5), "The row should still offer the capture menu")
-        appendMenu.click()
-
-        let existingJourney = app.menuItems["Checkout"]
-        XCTAssertTrue(
-            existingJourney.waitForExistence(timeout: 5),
-            "The submenu should list the journey that now exists"
+        let appended = UITestApp.chooseFromSubmenu(
+            in: app,
+            parent: appendMenu,
+            item: app.menuItems["Checkout"],
+            thenAwait: element(identifiedBy: "journeyStep-1"),
+            reopenMenu: { self.logRow(identifiers[0]).rightClick() },
+            outcomeTimeout: 10
         )
-        existingJourney.click()
-
-        XCTAssertTrue(
-            element(identifiedBy: "journeyStep-1").waitForExistence(timeout: 10),
-            "Appending should add a second step to the journey and show it"
-        )
+        if !appended {
+            let visible = app.menuItems.allElementsBoundByIndex.prefix(8).map(\.title)
+            XCTFail(
+                "Appending should add a second step to the journey and show it. "
+                    + "openMenus=\(app.menus.count) visibleMenuItems=\(visible) "
+                    + "captureMenuPresent=\(appendMenu.exists)"
+            )
+        }
     }
 
     // MARK: - LOGSEL


### PR DESCRIPTION
Two independent changes on one branch — this repository's automation develops on a single designated branch, so they arrive together. They touch disjoint files and can be reviewed as two commits.

---

# 1. Stop losing the click that drives the capture submenu

`f392030` — `MimicUITests/`

## The failure

Run #98 left `main` red on `RequestLogUITests.testAddingRequestsToAnExistingJourneyFromTheLog`, at line 1042, **twice in the same run** (53 test runs for 52 tests — it failed, retried, and failed again):

```
RequestLogUITests.swift:1042: XCTAssertTrue failed -
  Capturing into a new journey should ask for a name first
```

That line already carried a fix, and it was the wrong one. It failed on run #91 at a five-second wait, passed on the retry, and was widened to fifteen seconds under a comment explaining that the sheet was coming and the machine had been busy.

**It failed at fifteen.** A sheet that is merely slow arrives inside fifteen seconds, so the clock was never the variable. Widening a timeout is what you do when something arrives late — not when it never arrives.

## What is actually happening

A lost click, and it has two sites.

**The menu.** `waitForExistence` returns when an element enters the accessibility tree, which for an AppKit menu is when the menu is *created* — before it is positioned, and while it is still fading in. `click()` then resolves the element again, takes the frame from that snapshot, and synthesizes an event at its centre. A frame that is a moment stale puts the event on the menu's backdrop: the menu closes, the action never runs, and the only evidence is the absence of the sheet — indistinguishable from the app failing to present one.

**The layout underneath it.** Three lines earlier, selecting a log row opens the inspector inside `withAnimation(DSAnimation.drawerToggle)`, which narrows the drawer and moves every row. The ⌘-click and right-click that follow are both aimed at a frame. A ⌘-click landing between two rows selects nothing, and presents as the modifier having been dropped rather than as a moved target — the misreading this suite has already paid for once.

Both tests that drive the capture submenu have flaked, in two different suites, which is what says the mechanism is the problem rather than either test.

## The change

- **`UITestApp.waitForStableFrame(_:)`** — polls until an element reports the same non-empty frame twice. `snapshot()` rather than `.frame`, because reading `.frame` on an element that has gone away raises an XCTest failure and every suite here runs `continueAfterFailure = false`, so a menu that closed underneath the helper would end the test instead of letting the caller retry.
- **`UITestApp.chooseFromSubmenu(in:parent:item:thenAwait:reopenMenu:…)`** — settles both menu levels before clicking them and, if the outcome still does not arrive, dismisses what is left open and drives the whole interaction again. Only the last attempt gets the full outcome timeout, so a missed click is discovered in four seconds rather than fifteen.

Applied to the three nested-menu interactions in the suite. They are the only ones — every other `menuItems[…]` in `MimicUITests/` is a flat context menu or a pop-up picker.

## About the retry, since a retry can hide the thing it is meant to survive

- **It cannot turn a broken app green.** Every attempt ends waiting for the same `outcome` element, so a capture that does not present still fails, with the caller's own message. What the retry removes is the click being lost, not the sheet being absent.
- **It cannot tell a missed click apart from an app that intermittently fails to present.** Each re-open is therefore recorded with `XCTContext.runActivity`, which lands in the result bundle — the only place that distinction can be recovered afterwards. `print()` would not do: runner output never reaches the xcodebuild log CI reads.

Failure messages now name what the tree held rather than restating the expectation. `journeyEditorOpen` is the discriminator worth having: a journey that exists without the sheet ever appearing means the action *ran* and the presentation was dropped, which would be the app's fault and not the click's.

Lesson written into `.agents/skills/mimic-ui-tests/references/accessibility-tree.md`, next to the two existing menu rules.

---

# 2. Make the first badge report coverage, not the entry point

`a3199c1` — `Scripts/update_readme_coverage.py`, `README.md`, `ci.md`

## The problem

The badge reads `Mimic.app coverage 46.67%`, and the number is correct. What it *measures* is `Mimic.app` — the app **bundle target**, which is `App/Sources/MimicApp.swift`: 34 lines of `@main` entry point that `xccov` counts as 60 executable ones, 28 covered.

Merging the XCUITest bundles in #60 moved `AppFeatures` from 85.32% to **97.48%** and did not move this figure at all, because the entry point runs identically either way. That is the diagnosis: a badge whose number cannot move when the tests improve is not reporting on the tests.

The application is `AppFeatures`, and it is one row in the *other* badge's eight.

## The change

The first badge publishes the **weighted total across all nine targets** — covered lines over executable lines, computed once. On run #98's merged figures that is 26,347/27,211 = **96.82%**, brightgreen.

Weighted, not a mean: averaging nine percentages weights `ControlPlane`'s 413 lines the same as `AppFeatures`' 17,848.

**Summing across targets is exact, and it deliberately looks like the thing `ci.yml` refuses to do.** It is a different operation. Merging four *test runs* cannot be done by adding — a line two suites both reach is one covered line in the union, which is why the workflow merges result bundles. These nine targets are disjoint sets of source files in one already-merged report, so no line appears twice. Both halves of that distinction are written down where each belongs.

`app-coverage.json` keeps its name. It is a URL `README.md` carries and the `badges` branch serves, so renaming it would leave a merged README pointing at a file the next run has not published yet — both badges rendering shields.io's "invalid" placeholder for the length of a CI run. A file name nobody reads is the cheaper inaccuracy, and the comment above it is the price.

The generated README block gains an **All nine targets** row carrying the same figure, plus a note saying what `Mimic.app` actually is, so a reader comparing badge against table does not have to add nine numbers by hand.

## Verification of this half

The self-test pins the weighted total as a literal computed by hand — 2,281/3,809 = 59.88% over the existing fixtures — in the payload arm, the on-disk arm, and the block arm, so the badge and the table cannot disagree. Deliberately **not** the mean of those fixtures (72.58%) and **not** the app figure (41.50%): those are the two wrong answers being replaced.

Negative control run: pointing the payload back at `app_metrics` turns the self-test red in two places.

Checked against run #98's real merged figures rather than fixtures alone — `--from-json --emit-badges` over them produces `{"label": "line coverage", "message": "96.82%", "color": "brightgreen"}`.

---

# Verification

All eleven toolchain-free gates pass, including `check_house_rules.sh` (which enforces "tests never sleep" — the new waits are built on `UITestApp.waitUntil`, not a pause) and `update_readme_coverage.py --self-test`.

**Not verified here, and I am not claiming otherwise:** this container has no Swift toolchain and no Xcode, so nothing was compiled or run. The UI half is test-only, so the three UI shards on this pull request are its whole verdict. The badge half cannot be exercised on a pull request at all — the coverage jobs run on pushes to `main` only — so the first `main` run after merge is what shows the new figure.

## For reference: what #60 actually measured

Run #98 was the first run of the merged-coverage pipeline, and it worked end to end — download, merge, two reports and publish in 38 seconds. The sandbox did **not** block the app's `.profraw`, which was the open question:

| Target | Unit only | Merged |
|---|---:|---:|
| AppFeatures | 85.32% | **97.48%** |
| DesignSystem | 97.13% | 99.24% |
| Persistence | 98.12% | 99.60% |
| MockServerEngine | 96.88% | 98.30% |
| Domain | 96.15% | 96.96% |
| SpecImport | 97.14% | 96.91% |
| MimicCLICore | 86.72% | 87.68% |
| ControlPlane | 84.75% | 84.02% |
| Mimic.app | 46.67% | 46.67% |

Weighted total: 88.5% → **96.8%**. `ControlPlane` and `MimicCLICore` are the two still under 95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SpJbSWRnbQwtCexsZjpNz
