### PR TITLE
Make the first badge report coverage, not the entry point

### DIFF
--- a/.agents/skills/mimic-build-and-test/references/ci.md
+++ b/.agents/skills/mimic-build-and-test/references/ci.md
@@ -88,15 +88,31 @@ shields.io *endpoint* payloads with `Scripts/update_readme_coverage.py --from-js
 and force-pushes them to the `badges` branch:
 
 ```
-badges/app-coverage.json      {"schemaVersion": 1, "label": "Mimic.app coverage",
-                               "message": "72.41%", "color": "red"}
+badges/app-coverage.json      {"schemaVersion": 1, "label": "line coverage",
+                               "message": "96.82%", "color": "brightgreen"}
 badges/module-coverage.json   {"schemaVersion": 1, "label": "modules at or above 95%",
-                               "message": "5/8", "color": "red"}
+                               "message": "6/8", "color": "red"}
 ```
 
 Four keys, nothing else — no timestamp, no run URL. The colour comes from the same ladder the badges
 have always used (95% brightgreen, 90% green, 80% yellow, below that red), and the module badge is
-coloured by the *proportion* clearing the bar, so `5/8` is 62.5% and red while `8/8` is bright green.
+coloured by the *proportion* clearing the bar, so `6/8` is 75% and red while `8/8` is bright green.
+
+**The first payload's file name does not describe what it carries, and that is deliberate.** It
+published `Mimic.app coverage` once — the app *bundle* target, which is `App/Sources/MimicApp.swift`,
+34 lines of `@main` entry point that `xccov` counts as 60 executable ones, and it read `46.67%` while
+readers took it for a statement about the application. It carries the **weighted total across all
+nine targets** now: covered lines over executable lines, computed once, not a mean of nine
+percentages that would weight `ControlPlane`'s 413 lines the same as `AppFeatures`' 17,848.
+
+Summing across targets is exact where summing across *runs* is not — the nine are disjoint sets of
+source files in one already-merged report, so no line is in two of them. That is the same distinction
+the merge above rests on, read the other way round.
+
+`app-coverage.json` keeps its name because it is a URL README.md carries and the `badges` branch
+serves: renaming it would leave a merged README pointing at a file the next run has not published
+yet, so both badges would render shields.io's "invalid" placeholder for the length of a CI run. A
+file name nobody reads is the cheaper inaccuracy.
 
 The README links each through `https://img.shields.io/endpoint?url=…`, percent-encoded, at
 `raw.githubusercontent.com/srpadrono/mimic/badges/<file>`. **Nothing in the tracked tree moves when

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ failures, and watch live traffic. Then drive all of it from a script.
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
 [![Tests](https://img.shields.io/badge/tests-1145%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![App Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
+[![Line Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
 [![Module Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json)](#coverage)
 
 [Install](#install) · [Quickstart](#quickstart) · [Journeys](#journeys) · [CLI](docs/CLI.md) · [Architecture](docs/ARCHITECTURE.md)
@@ -301,11 +301,18 @@ That merge is why the numbers moved. Until it existed the badges came from a run
 `-skip-testing:MimicUITests`, so all 158 UI tests — the only ones that touch the SwiftUI layer —
 contributed nothing to the published figure for how well this window is tested.
 
-Two things the badges are not. The first reads `Mimic.app coverage`, and `Mimic.app` is the app
-bundle *target*: `App/Sources/MimicApp.swift`, 34 lines, the `@main` entry point. The application
-itself is `AppFeatures`, which the second badge counts among its eight modules. And a run that
-publishes nothing leaves both showing the last figures that did publish — deliberately, since a
-stale number is recoverable and a quietly wrong one is not.
+**The first badge is the weighted total over all nine targets** — covered lines divided by
+executable lines, once, not a mean of nine percentages. Summing across targets is exact where
+summing across *runs* would not be: the nine are disjoint sets of source files in one already-merged
+report, so no line is counted twice.
+
+It used to read `Mimic.app coverage`, and it measured the target of that name — which is
+`App/Sources/MimicApp.swift`, 34 lines of `@main` entry point. It published `46.67%` and readers
+took that for a statement about the application. The application is `AppFeatures`; `Mimic.app` keeps
+its row in the table below.
+
+A run that publishes nothing leaves both badges showing the last figures that did publish —
+deliberately, since a stale number is recoverable and a quietly wrong one is not.
 
 The detailed per-target block below is the other half, and it is deliberately local-only —
 `./Scripts/run_full_test_suite.sh` on a Mac is its only writer, so it is as fresh as the last full

--- a/Scripts/update_readme_coverage.py
+++ b/Scripts/update_readme_coverage.py
@@ -102,9 +102,25 @@ BADGE_BRANCH = "badges"
 APP_BADGE_FILE = "app-coverage.json"
 MODULE_BADGE_FILE = "module-coverage.json"
 
-# The labels the badges have always carried, kept verbatim so the two badges do not change wording
-# on the day they start carrying a number.
-APP_BADGE_LABEL = "Mimic.app coverage"
+# The file names are addresses and the labels are descriptions, and only one of the two is allowed
+# to lie for a while.
+#
+# The first badge used to read `Mimic.app coverage`, and measured the target of that name — which is
+# `App/Sources/MimicApp.swift`, thirty-four lines of `@main` entry point that `xccov` counts as sixty
+# executable ones. It published `46.67%`: twenty-eight of those sixty lines. A reader took that for a
+# statement about the application, and it was a statement about a shim. The application is
+# `AppFeatures`, fourteen thousand lines of it, and it is one row in the *other* badge's eight.
+#
+# It reads the **weighted total across all nine targets** now, which is the figure the label always
+# implied. `Mimic.app` keeps its row in the table and its entry in the JSON — sixty lines of entry
+# point is worth reporting, just not worth being the headline.
+#
+# `APP_BADGE_FILE` deliberately keeps its name through that change. It is a URL README.md carries and
+# the `badges` branch serves; renaming it would leave the merged README pointing at a file the next
+# run has not published yet, so both badges would render shields.io's "invalid" placeholder for the
+# length of a CI run. A file name nobody reads is the cheaper inaccuracy, and this paragraph is the
+# price of it.
+TOTAL_BADGE_LABEL = "line coverage"
 MODULE_BADGE_LABEL = "modules at or above 95%"
 
 
@@ -253,15 +269,23 @@ def build_coverage_block(
         lines.append(f"| `{target_name}` | `{format_percent(metrics.percent)}` | `{format_lines(metrics)}` |")
 
     at_or_above = modules_at_or_above_95(module_metrics)
-    total_executable_lines = app_metrics.executable_lines + sum(metrics.executable_lines for _, metrics in module_metrics)
+    total = total_metrics(app_metrics, module_metrics)
+    # The row the first badge publishes, in the table it belongs to. Without it a reader comparing
+    # the badge against this block has to add nine numbers by hand to find out where it came from.
+    lines.append(f"| **All nine targets** | **`{format_percent(total.percent)}`** | **`{format_lines(total)}`** |")
     lines.extend(
         [
             "",
             "Coverage notes:",
             "",
-            f"- App coverage is currently `{format_percent(app_metrics.percent)}`.",
+            f"- Total line coverage across all nine targets is `{format_percent(total.percent)}` — "
+            "the figure the first badge at the top of this file publishes.",
+            f"- `Mimic.app` is the app *bundle* target: `App/Sources/MimicApp.swift`, the `@main` "
+            f"entry point, currently `{format_percent(app_metrics.percent)}` of "
+            f"`{app_metrics.executable_lines:,}` executable lines. The application itself is "
+            "`AppFeatures`.",
             f"- Modules at or above `95%`: `{at_or_above}/{len(module_metrics)}`.",
-            f"- Total executable lines tracked in this table: `{total_executable_lines:,}`.",
+            f"- Total executable lines tracked in this table: `{total.executable_lines:,}`.",
             "- `Lines` shows covered/executable lines reported by `xcrun xccov`.",
             "- Coverage is gathered with `xcodebuild` and `xcrun xccov` from fresh `.xcresult` bundles.",
             f"- {provenance}",
@@ -327,6 +351,33 @@ def modules_at_or_above_95(module_metrics: list[tuple[str, CoverageMetrics]]) ->
     return sum(1 for _, metrics in module_metrics if metrics.percent >= 95.0)
 
 
+def total_metrics(
+    app_metrics: CoverageMetrics, module_metrics: list[tuple[str, CoverageMetrics]]
+) -> CoverageMetrics:
+    """All nine targets as one figure: covered lines over executable lines, not a mean of percents.
+
+    A mean would weight `ControlPlane`'s 413 lines the same as `AppFeatures`' 17,848 and produce a
+    number that describes nothing. Summing the two counts and dividing once is the only honest
+    aggregate, and it is what a reader assumes a coverage badge already is.
+
+    **Summing across targets is sound, and it looks like the thing the workflow refuses to do.** It
+    is not the same operation. Merging four *test runs* cannot be done by adding, because a line the
+    unit suites reach and a UI test also reaches is one covered line in the union and adding counts
+    it twice — that is why `.github/workflows/ci.yml` merges the result bundles instead. These nine
+    targets are disjoint sets of source files, measured in one already-merged report, so no line
+    appears in two of them and the sum is exact.
+    """
+    covered = app_metrics.covered_lines + sum(m.covered_lines for _, m in module_metrics)
+    executable = app_metrics.executable_lines + sum(m.executable_lines for _, m in module_metrics)
+    if executable == 0:
+        raise RuntimeError("the coverage figures carry no executable lines at all.")
+    return CoverageMetrics(
+        percent=100.0 * covered / executable,
+        covered_lines=covered,
+        executable_lines=executable,
+    )
+
+
 def badge_payloads(
     app_metrics: CoverageMetrics, module_metrics: list[tuple[str, CoverageMetrics]]
 ) -> dict[str, dict]:
@@ -339,12 +390,13 @@ def badge_payloads(
     """
     at_or_above = modules_at_or_above_95(module_metrics)
     module_count = len(module_metrics)
+    total = total_metrics(app_metrics, module_metrics)
     return {
         APP_BADGE_FILE: {
             "schemaVersion": 1,
-            "label": APP_BADGE_LABEL,
-            "message": format_percent(app_metrics.percent),
-            "color": badge_color(app_metrics.percent),
+            "label": TOTAL_BADGE_LABEL,
+            "message": format_percent(total.percent),
+            "color": badge_color(total.percent),
         },
         MODULE_BADGE_FILE: {
             "schemaVersion": 1,
@@ -682,8 +734,14 @@ def self_test() -> int:
         == {
             "app-coverage.json": {
                 "schemaVersion": 1,
-                "label": "Mimic.app coverage",
-                "message": "41.50%",
+                "label": "line coverage",
+                # The weighted total, computed by hand from the fixtures above and written out as a
+                # literal: (1,000 + 960 + 321) / (2,409 + 1,000 + 400) = 2,281 / 3,809 = 59.8845…%.
+                # Deliberately *not* the mean of 41.5, 96.0 and 80.25 — that is 72.58%, and a badge
+                # showing it would be weighting a 400-line module the same as a 2,409-line one.
+                # Deliberately not `app.percent` either, which is 41.50% and is what this badge used
+                # to publish about a thirty-four-line entry point.
+                "message": "59.88%",
                 "color": "red",
             },
             "module-coverage.json": {
@@ -703,6 +761,17 @@ def self_test() -> int:
     )
     check("`Domain.framework` | `96.00%` | `960/1,000`" in rendered, "a module row is missing or misformatted")
     check("- Modules at or above `95%`: `1/2`." in rendered, "the at-or-above-95 count is wrong in the block")
+    # The same literal as the badge fixture above, and the point of pinning it in both places is that
+    # the block and the badge must not be able to disagree: a reader who checks one against the other
+    # is doing what this row exists for.
+    check(
+        "| **All nine targets** | **`59.88%`** | **`2,281/3,809`** |" in rendered,
+        "the total row is missing, or is not the weighted total of the rows above it",
+    )
+    check(
+        "Total line coverage across all nine targets is `59.88%`" in rendered,
+        "the block does not state the figure the first badge publishes",
+    )
     check("Prose that must survive untouched." in rendered, "prose outside the markers was lost")
     check("Trailing prose." in rendered, "prose after the block was lost")
     check(rendered.count("coverage:generated:start") == 1, "the start marker was duplicated or dropped")
@@ -747,8 +816,11 @@ def self_test() -> int:
             json.loads((badge_dir / "app-coverage.json").read_text())
             == {
                 "schemaVersion": 1,
-                "label": "Mimic.app coverage",
-                "message": "41.50%",
+                "label": "line coverage",
+                # 2,281/3,809 again, and written out again rather than referred to: this arm is the
+                # one that proves the figure survives the JSON hand-off from the macOS job to the
+                # Linux one, so it has to state the answer independently of the arm above.
+                "message": "59.88%",
                 "color": "red",
             },
             "the app payload on disk is not the document shields.io expects",


### PR DESCRIPTION
## The problem

The badge reads `Mimic.app coverage 46.67%`, and the number is correct. What it *measures* is the `Mimic.app` target — the app **bundle**, which is `App/Sources/MimicApp.swift`: 34 lines of `@main` entry point that `xccov` counts as 60 executable ones, 28 of them covered.

Merging the XCUITest bundles in #60 moved `AppFeatures` from 85.32% to **97.48%** and moved this figure by exactly zero, because the entry point runs identically either way. That is the diagnosis, not a coincidence: **a badge whose number cannot move when the tests improve is not reporting on the tests.**

The application is `AppFeatures`, and it is one row in the *other* badge's eight.

## The change

The first badge publishes the **weighted total across all nine targets** — covered lines over executable lines, computed once. On run #98's merged figures that is 26,347/27,211 = **96.82%**, brightgreen, labelled `line coverage`.

| | before | after |
|---|---|---|
| label | `Mimic.app coverage` | `line coverage` |
| message | `46.67%` | `96.82%` |
| what it measures | 60 executable lines of `@main` | all 27,211 executable lines |

**Weighted, not a mean.** Averaging nine percentages weights `ControlPlane`'s 413 lines the same as `AppFeatures`' 17,848 and produces a number that describes nothing. On the self-test's fixtures the mean is 72.58% and the weighted total is 59.88% — both are pinned, so the wrong one cannot quietly become the right one.

**Summing across targets is exact, and it deliberately looks like the thing `ci.yml` refuses to do.** It is a different operation. Merging four *test runs* cannot be done by adding, because a line the unit suites reach and a UI test also reaches is one covered line in the union — that is why the workflow merges result bundles with `xcresulttool`. These nine targets are disjoint sets of source files inside one already-merged report, so no line appears in two of them and the sum is exact. Both halves of that distinction are now written down where each belongs.

**`app-coverage.json` keeps its name.** It is a URL `README.md` carries and the `badges` branch serves. Renaming it would leave a merged README pointing at a file the next run has not published yet, so both badges would render shields.io's "invalid" placeholder for the length of a CI run. A file name nobody reads is the cheaper inaccuracy, and the comment above the constant is the price of it.

The generated README block gains an **All nine targets** row carrying the same figure, plus a note saying what `Mimic.app` actually is — so a reader comparing the badge against the table does not have to add nine numbers by hand, and cannot mistake the entry-point row for the application again.

## Verification

The self-test pins the weighted total as a literal computed by hand — 2,281/3,809 = 59.88% over the fixtures that were already there — in three places: the payload arm, the on-disk `--emit-badges` arm, and the rendered-block arm, so the badge and the table cannot disagree with each other.

**Negative control run:** pointing the payload back at `app_metrics` turns the self-test red in two places. The fixture does not move with the mechanism.

Checked against run #98's real merged figures as well as the fixtures — `--from-json --emit-badges` over them produces:

```json
{ "schemaVersion": 1, "label": "line coverage", "message": "96.82%", "color": "brightgreen" }
```

All eleven toolchain-free gates pass.

**Not verified here, and I am not claiming otherwise:** this container has no Swift toolchain and no Xcode. Nothing Swift was built or run, and nothing needed to be — this changes one Python script and two documents. What *cannot* be exercised on a pull request at all is the publish itself: the coverage jobs run on pushes to `main` only, so the badge changes on the first `main` run after this merges, roughly 35 minutes later, not at the merge.

## Where the figures come from

Run #98, the first run of the merged-coverage pipeline from #60:

| Target | Unit only | Merged |
|---|---:|---:|
| AppFeatures | 85.32% | 97.48% |
| DesignSystem | 97.13% | 99.24% |
| Persistence | 98.12% | 99.60% |
| MockServerEngine | 96.88% | 98.30% |
| Domain | 96.15% | 96.96% |
| SpecImport | 97.14% | 96.91% |
| MimicCLICore | 86.72% | 87.68% |
| ControlPlane | 84.75% | 84.02% |
| Mimic.app | 46.67% | 46.67% |
| **All nine** | **88.46%** | **96.82%** |

`ControlPlane` and `MimicCLICore` are the two still under 95%, which is what the second badge's `6/8` is counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SpJbSWRnbQwtCexsZjpNz


---
_Generated by [Claude Code](https://claude.ai/code/session_012SpJbSWRnbQwtCexsZjpNz)_