### PR TITLE
Fix four geometry faults in the editor well and the inspector's tab strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ failures, and watch live traffic. Then drive all of it from a script.
 
 [![Platform](https://img.shields.io/badge/platform-macOS%2026%2B-blue)](https://developer.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
-[![Tests](https://img.shields.io/badge/tests-1188%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1190%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Line Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
 [![Module Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json)](#coverage)
@@ -261,13 +261,13 @@ every command through the shipped host. See [AGENTS.md](AGENTS.md#one-host) and
 
 ## Testing
 
-1188 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
+1190 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
 and is still one declaration. Swift Testing for units, XCTest with page objects for UI.
 
 | Suite | Count | Where it runs |
 |-------|-------|---------------|
 | Domain, persistence, engine, control plane, import, CLI | 662 | Linux or macOS — `swift test` |
-| Design system | 69 | macOS — needs SwiftUI |
+| Design system | 71 | macOS — needs SwiftUI |
 | App and coordination | 299 | macOS — hosted by the app |
 | macOS UI (XCUITest) | 158 | macOS, interactive session |
 

--- a/Sources/AppFeatures/EndpointFeature/EndpointEditorView.swift
+++ b/Sources/AppFeatures/EndpointFeature/EndpointEditorView.swift
@@ -61,9 +61,15 @@ private enum EditorRowMetrics {
 /// to type, and above the ceiling a 500-line payload runs off the window instead of scrolling inside
 /// the well that owns it.
 private enum EditorBody {
-    /// Roughly seven lines. Sized to be a comfortable place to start typing, and to absorb a
-    /// minified payload — one logical line that wraps to several, which `lineCount` cannot see.
-    static let minHeight: CGFloat = 100
+    /// Twelve lines. The floor is the only thing standing between a *wrapped* body and a slit:
+    /// `wrapText` is on, so a minified payload is one logical line that fills the pane, and
+    /// `lineCount` counts logical lines and reports 1.
+    ///
+    /// It was briefly 100, which is 6.6 visible lines — less than the 240 the same body used to get,
+    /// so the change meant to give the pane back to its content took it away from the one body that
+    /// needs it most. 180 is what that case had before and is the number to keep until the wrap is
+    /// actually estimated.
+    static let minHeight: CGFloat = 180
 
     /// Unchanged. Past this the payload scrolls within its own well rather than pushing the cards
     /// below it off the pane.
@@ -71,12 +77,22 @@ private enum EditorBody {
 
     /// The well's natural height for this text, before the bounds are applied.
     ///
-    /// `DSJSONEditor` owns the arithmetic because it owns the font. The editor's frame also has to
-    /// cover the validation row it draws underneath itself when the JSON does not parse, which is
-    /// why this adds a line's worth rather than measuring the editor alone.
+    /// `DSJSONEditor` owns the arithmetic because it owns the font.
+    ///
+    /// The frame wraps the editor *and* the validation row it draws underneath itself when the JSON
+    /// does not parse, so that row's height has to be added rather than borrowed. It was borrowed —
+    /// as "one more editor line" — and an editor line is 15pt where the row measures 18: an 11pt
+    /// `Text` laying out at 14, plus `DSSpacing.xs` of top padding. The fixed row takes its height
+    /// first, so the three-point shortfall came off the editor and clipped the descenders on its
+    /// last line.
     static func height(for text: String) -> CGFloat {
-        DSJSONEditor.height(forLines: DSJSONEditor.lineCount(of: text) + 1)
+        DSJSONEditor.height(forLines: DSJSONEditor.lineCount(of: text)) + validationRowHeight
     }
+
+    /// The validation row `DSJSONEditor` draws under itself: an 11pt `Text` at 14pt of layout, plus
+    /// `DSSpacing.xs` above it. Reserved unconditionally — a well that changes height when the JSON
+    /// stops parsing would move every card below it while you are typing.
+    static let validationRowHeight: CGFloat = 14 + DSSpacing.xs
 }
 
 private enum EditorField {
@@ -543,9 +559,18 @@ struct EndpointEditorView: View {
         // `DSJSONEditor.height(forLines:)` measures the face the editor actually draws with. The
         // floor is what absorbs a *minified* payload, which is one logical line that wraps to many
         // and so under-reports — see that method's note.
+        // **`maxHeight` does not clamp here, and the ceiling has to be applied to the ideal.**
+        //
+        // `.frame(minHeight:idealHeight:maxHeight:)` clamps against a *proposal*, and the enclosing
+        // `ScrollView` proposes nil height — so the frame resolves to `idealHeight` verbatim and the
+        // ceiling never fires. That was harmless while the ideal was a fixed 240; the moment it
+        // became content-derived, a 200-line body rendered a 3,000pt well and pushed everything under
+        // it that far off the pane. Pressing Format on a minified body did it in one click.
+        //
+        // `maxHeight` stays as the guard for the case where something *does* propose a height.
         .frame(
             minHeight: EditorBody.minHeight,
-            idealHeight: EditorBody.height(for: responseBody),
+            idealHeight: min(EditorBody.height(for: responseBody), EditorBody.maxHeight),
             maxHeight: EditorBody.maxHeight
         )
         .padding(.horizontal, DSSpacing.md)

--- a/Sources/AppFeatures/WorkspaceFeature/InspectorPanelView.swift
+++ b/Sources/AppFeatures/WorkspaceFeature/InspectorPanelView.swift
@@ -191,12 +191,19 @@ struct InspectorPanelView: View {
                             // title, with a hard edge at the strip's boundary.
                             drawsChrome: false
                         )
-                        // No `.fixedSize()`. It made the strip claim its full width before the
-                        // subtitle got a say, and the subtitle here is the endpoint's *path* — so a
-                        // 200pt inspector header rendered "/accoun...ummary", which saves four
-                        // characters and reads as a rendering fault. The strip is icon-only and
-                        // already sized by its content; the rigidity was only ever costing the
-                        // string next to it.
+                        // `.fixedSize()` is load-bearing and was briefly removed in error.
+                        //
+                        // `DSTabStrip` ends its `HStack` with `Spacer(minLength: 0)` so an accessory
+                        // can hold the trailing edge. With no accessory — which is this call site —
+                        // that spacer is a greedy trailing element, and without `.fixedSize()` the
+                        // strip becomes infinitely flexible and swallows the whole header: the tabs
+                        // park against the title and the "+" is stranded at the far right, the gap
+                        // between them growing with the panel. Measured at 10pt with it, and
+                        // 35/95/215/455pt without it at header widths 220/280/400/640.
+                        //
+                        // It was removed to buy width for the subtitle — and then the same change
+                        // made `headerSubtitle` nil, so there was nothing left to buy width for.
+                        .fixedSize()
 
                         // Only on the tab it acts on — a "+" above a traffic list would have
                         // nothing to add to.

--- a/Sources/DesignSystem/Components/DSJSONEditor.swift
+++ b/Sources/DesignSystem/Components/DSJSONEditor.swift
@@ -117,8 +117,15 @@ public struct DSJSONEditor: View {
     /// The number of logical lines in `text` — what ``height(forLines:)`` wants.
     ///
     /// An empty document is one line, not zero: an empty editor still shows a caret on a line.
+    ///
+    /// **Split on `isNewline`, not on `"\n"`.** Counting `Character == "\n"` looks equivalent and is
+    /// not: `"\r\n"` is a *single* grapheme cluster that compares unequal to `"\n"`, so a CRLF
+    /// document — a HAR capture, a Windows-authored fixture — counted as one line no matter how long
+    /// it was. `CodeEditorView` disagrees with that reading, because its own line map splits with
+    /// `NSString.lineRange(for:)`, which honours CR, CRLF, U+2028, U+2029 and U+0085. `isNewline`
+    /// matches that set, so the well and the gutter now count the same lines.
     public static func lineCount(of text: String) -> Int {
-        text.isEmpty ? 1 : text.reduce(1) { $1 == "\n" ? $0 + 1 : $0 }
+        text.isEmpty ? 1 : text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).count
     }
 
     // MARK: - Themes — warm, cohesive with Ink & Electric palette

--- a/Tests/DesignSystemTests/DSJSONEditorTests.swift
+++ b/Tests/DesignSystemTests/DSJSONEditorTests.swift
@@ -161,6 +161,42 @@ struct DSJSONEditorSizingTests {
         #expect(DSJSONEditor.lineCount(of: "{\n  \"a\": 1\n}") == 3)
     }
 
+    /// Every separator `NSString.lineRange(for:)` honours, because that is what `CodeEditorView`
+    /// builds its own line map with — and the well and the gutter have to agree on how many lines
+    /// there are.
+    ///
+    /// **This is the regression test for a bug the LF-only cases above could never catch.** The old
+    /// implementation compared `Character == "\n"`, which looks equivalent to splitting on newlines
+    /// and is not: `"\r\n"` is a *single* grapheme cluster that compares unequal to `"\n"`, so a
+    /// CRLF document counted as **one line no matter how long it was**. A HAR capture or any
+    /// Windows-authored fixture therefore sized its editor well to a single line. Measured before the
+    /// fix: a four-line CRLF document counted 1, and CR, U+2028, U+2029 and U+0085 each counted 1 for
+    /// a two-line document.
+    @Test("Every newline the editor's own line map honours is counted")
+    func lineCountHonoursEveryNewlineSeparator() {
+        // Literals, not derived from the function under test — reverting `isNewline` to the old
+        // `== "\n"` must turn every one of these red.
+        #expect(DSJSONEditor.lineCount(of: "a\r\nb\r\nc\r\nd") == 4)
+        #expect(DSJSONEditor.lineCount(of: "a\rb") == 2)
+        #expect(DSJSONEditor.lineCount(of: "a\u{2028}b") == 2)
+        #expect(DSJSONEditor.lineCount(of: "a\u{2029}b") == 2)
+        #expect(DSJSONEditor.lineCount(of: "a\u{0085}b") == 2)
+
+        // And a CRLF document must be exactly as tall as the LF document that says the same thing.
+        #expect(DSJSONEditor.lineCount(of: "a\r\nb") == DSJSONEditor.lineCount(of: "a\nb"))
+    }
+
+    /// The consequence, stated in the units the view actually uses: a CRLF payload must not collapse
+    /// to a one-line well.
+    @Test("A CRLF payload gets the height its lines deserve")
+    func crlfPayloadIsNotSizedToOneLine() {
+        let crlf = (0..<20).map { "  \"key\($0)\": \($0)" }.joined(separator: "\r\n")
+
+        #expect(DSJSONEditor.lineCount(of: crlf) == 20)
+        #expect(DSJSONEditor.height(forLines: DSJSONEditor.lineCount(of: crlf))
+                > DSJSONEditor.height(forLines: 1))
+    }
+
     @Test("A trailing newline opens a line rather than closing one")
     func trailingNewlineOpensALine() {
         // The caret sits *after* the separator, on a line of its own, and the well has to have room


### PR DESCRIPTION
Four fixes that were sitting **uncommitted in the working tree**, plus the regression test the worst of them needed. None is on `main` — #63 merged the earlier redesign work and left these behind.

## `lineCount` counted a CRLF document as one line, however long it was

It compared `Character == "\n"`, which looks equivalent to splitting on newlines and is not: `"\r\n"` is a **single grapheme cluster** that compares unequal to `"\n"`. A HAR capture, or any Windows-authored fixture, therefore sized its editor well to one line.

Measured before the fix:

| Document | Old count | New count |
|---|---|---|
| 4-line CRLF | **1** | 4 |
| 2-line CR | **1** | 2 |
| 2-line U+2028 / U+2029 / U+0085 | **1** | 2 |
| 20-line CRLF payload | **1** → a **15.0pt** well | 20 |

15.0pt is exactly what `height(forLines: 1)` returns — the well collapsed to a single line.

`isNewline` matches the set `NSString.lineRange(for:)` honours, which is what `CodeEditorView` builds its own line map with, so the well and the gutter now count the same lines.

**The regression test is a real negative control.** Separators are pinned as literals rather than derived from the function under test; reverting `isNewline` to the old comparison turns it red with 8 failures. That is how the numbers above were measured.

## `idealHeight` was unclamped, and `maxHeight` never fired

`.frame(minHeight:idealHeight:maxHeight:)` clamps against a *proposal*, and the enclosing `ScrollView` proposes nil height — so the frame resolved to `idealHeight` verbatim. Harmless while the ideal was a fixed 240; the moment it became content-derived, a 200-line body rendered a **~3,000pt well** and pushed everything beneath it that far off the pane. Pressing **Format** on a minified body did it in one click.

## The validation row's height was borrowed rather than added

Counted as "one more editor line" — but an editor line is 15pt where the row measures 18 (an 11pt `Text` laying out at 14, plus `DSSpacing.xs`). The fixed row takes its height first, so the 3pt shortfall came off the editor and **clipped the descenders on its last line**.

## `.fixedSize()` on the inspector's `DSTabStrip` was load-bearing

`DSTabStrip` ends its `HStack` with `Spacer(minLength: 0)` so an accessory can hold the trailing edge. With no accessory — this call site — that spacer is greedy, and without `.fixedSize()` the strip swallows the header: tabs park against the title, the "+" strands at the far right, and the gap grows with the panel.

| Header width | With `.fixedSize()` | Without |
|---|---|---|
| 220 / 280 / 400 / 640 | 10pt | **35 / 95 / 215 / 455pt** |

It had been removed to buy width for the subtitle — and the same change then made `headerSubtitle` nil, so there was nothing left to buy width for.

## Also

`EditorBody.minHeight` returns to **180**. At 100 it was 6.6 visible lines, fewer than the 240 the same body used to get — so a change meant to give the pane back to its content took it away from the one body that needs it most: a wrapped payload, which `lineCount` cannot see.

## Verification

- Debug build
- **1032 unit tests across 105 suites**, `** TEST SUCCEEDED **`
- Both new tests confirmed to fail when the fix is reverted, and pass when it is restored

Not run: XCUITests. These are geometry changes and deserve a look on screen before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)