### PR TITLE
Stop the header-refusal UI test asserting the host's keyboard layout

### DIFF
--- a/MimicUITests/ErrorAlertUITests.swift
+++ b/MimicUITests/ErrorAlertUITests.swift
@@ -170,25 +170,55 @@ final class ErrorAlertUITests: MimicUITestCase {
     /// ones that trim to nothing, so `" "` produces the same empty dictionary the scenario already
     /// holds, `headersAreDirty` answers `false`, and no command is ever issued.
     ///
-    /// **A colon, one keystroke, is the trigger this uses**, and the choice is about determinism
-    /// rather than about taste. `":"` is not a `tchar` (RFC 9110 §5.6.2), so the *first* character
+    /// **A comma, one keystroke, is the trigger this uses**, and the choice is about determinism
+    /// rather than about taste. `","` is not a `tchar` (RFC 9110 §5.6.2), so the *first* character
     /// typed is already refused — with a name like `"X Bad"` the debounce commits the honest prefix
     /// `"X"` first, which is a perfectly valid header, and the refusal then arrives on some later
     /// keystroke with the remaining ones landing on an alert that is already up. One character means
     /// one settle, one command, one alert, and nothing typed into it afterwards. It is also the
-    /// vector `EndpointValidator.validateHeader` names: a colon in a name ends the name, and
-    /// everything after it is read by the client as a further header.
+    /// vector `EndpointValidator.validateHeader` names: a separator character in a name ends the
+    /// name, and everything after it is read by the client as a further header.
+    ///
+    /// **It used to type `":"`, and that made the test depend on the host's keyboard layout.** On a
+    /// British layout `:` is Shift-`;`, and `typeText(":")` is silently dropped — the field kept
+    /// whatever it already held and no command was ever issued, so the assertion that fired was the
+    /// one about the missing alert and it pointed squarely at the app's header validation. The
+    /// validation was never at fault; nothing had been typed for it to refuse. Proven by typing a
+    /// plain `"a"` first: the `a` landed and the `:` after it did not. `,` is unshifted on both US
+    /// and British layouts and is equally absent from the token grammar, so the test now asserts the
+    /// same rule without asserting anything about the machine it runs on.
     @MainActor
     func testRefusedHeaderNameRaisesTheCommandErrorAlert() throws {
         launchApp()
         createProjectViaUI(name: "Header Refusal")
         createEndpointViaUI(name: "Users", path: "/api/users")
 
+        // Hide the drawer and scroll each target into view before clicking it — the idiom every
+        // other editor test here uses. Not what was breaking this one, but this test was the only
+        // editor interaction in the suite that skipped it.
+        hideRequestLogDrawer()
+
+        XCTAssertTrue(addHeaderButton.waitForExistence(timeout: 5), "The editor should offer 'Add header'")
+        XCTAssertTrue(revealInEditor(addHeaderButton), "'Add header' should be reachable in the editor")
         addHeaderButton.click()
+
         let key = endpointEditor.headerKeyField(at: 0)
         XCTAssertTrue(key.waitForExistence(timeout: 5), "Adding a header should give the row a name field")
+        XCTAssertTrue(revealInEditor(key), "The header name field should be reachable in the editor")
         key.click()
-        key.typeText(":")
+        key.typeText(",")
+
+        // Prove the keystroke landed *before* waiting on anything downstream of it.
+        //
+        // Without this the test cannot tell "the app failed to refuse a bad header" from "the
+        // character never reached the field", and those have opposite fixes — the second one is what
+        // was actually happening, and it read as the first for as long as this check sat at the end
+        // of the test instead of here.
+        XCTAssertEqual(
+            (key.value as? String) ?? "",
+            ",",
+            "The comma should have landed in the header name field"
+        )
 
         // The 300ms settle, then `applyScenarioSpec` → `validateHeaders` → `lastCommandError`.
         XCTAssertTrue(
@@ -219,7 +249,7 @@ final class ErrorAlertUITests: MimicUITestCase {
         // field here — which is exactly the silent-revert this alert was added to end.
         XCTAssertEqual(
             (key.value as? String) ?? "",
-            ":",
+            ",",
             "The editor should still show the text the executor refused"
         )
     }


### PR DESCRIPTION
`ErrorAlertUITests.testRefusedHeaderNameRaisesTheCommandErrorAlert` **fails on `main`** (verified at `f16ec77`, clean tree). With this change the full UI suite is **158/158, `** TEST SUCCEEDED **`**.

## The test was asserting something about the machine, not about the app

It typed `":"` into a header name field and waited for the executor to refuse it. On a **British keyboard layout** `:` is Shift-`;`, and `typeText(":")` is silently dropped. The field stayed empty → no command was issued → no alert appeared → the assertion that fired was the one about the *missing alert*, pointing squarely at the app's header validation.

The validation was never at fault. Nothing had been typed for it to refuse.

## Proven, not guessed

Typing a plain `"a"` first and reading the field back:

```
after typing plain 'a':  Optional(a)     <- landed
after typing ':' too:    Optional(a)     <- vanished
```

A dump of all six text fields confirmed the colon reached **none** of them — it wasn't misrouted, it was lost. The field was hittable, enabled, and correctly targeted:

```
DIAG hittable=true enabled=true frame=(419.0, 299.0, 190.0, 17.0)
DIAG field[2] id=endpointEditor.headerKey.0  frame=(419.0, 299.0, 190.0, 17.0)
```

Only the shifted character failed.

## The fix

`,` is equally absent from the RFC 9110 token grammar (`isTokenScalar`, `EndpointValidation.swift:97`) and is **unshifted on both US and British layouts**. Same rule asserted; nothing asserted about the host.

## Two changes that were *not* the cause

Both cost real time to rule out, so they're fixed too:

- **The read-back now runs immediately after typing.** The check already existed — at the very *end* of the test, where the alert assertions in front of it meant it never ran. A keystroke that went nowhere therefore presented as an app defect for as long as anyone cared to look.
- **`hideRequestLogDrawer()` + `revealInEditor(_:)` before each click** — the idiom every other editor test here uses. This test was the only editor interaction in the suite that skipped both.

## Verification

| | Before | After |
|---|---|---|
| `MimicUITests` | 157 passed, **1 failed** | **158 passed, 0 failed** |

Independent of [#64](https://github.com/srpadrono/mimic/pull/64) — that PR was checked against this failure first and is innocent; the failure reproduces identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)