### PR TITLE
Add a repeatable way to regenerate the docs screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,6 +887,7 @@ jobs:
               -only-testing:MimicUITests/JourneyUITests
               -only-testing:MimicUITests/SpecImportUITests
               -only-testing:MimicUITests/ControlPlaneIsolationTests
+              -only-testing:MimicUITests/DocScreenshotTests
 
           # 53 tests.
           - id: 2

--- a/MimicUITests/DocScreenshotTests.swift
+++ b/MimicUITests/DocScreenshotTests.swift
@@ -16,7 +16,7 @@ import XCTest
 ///   -destination 'platform=macOS' -only-testing:MimicUITests/DocScreenshotTests
 /// ```
 ///
-**Grant the runner Documents access before the first run.** macOS raises a TCC prompt —
+/// **Grant the runner Documents access before the first run.** macOS raises a TCC prompt —
 /// *"MimicUITests-Runner would like to access files in your Documents folder"* — the first time a run
 /// touches the checkout, and until someone answers it the test **hangs** rather than failing: the
 /// dialog is modal, the runner waits, and `xcodebuild` sits there until it is killed. Worse for this
@@ -69,7 +69,12 @@ final class DocScreenshotTests: MimicUITestCase {
 
         // Let the window settle. A capture taken mid-transition catches a half-drawn panel, and that
         // is the kind of defect nobody notices until the image is in the README.
-        Thread.sleep(forTimeInterval: 1.5)
+        //
+        // Polled, not paused: `UITestApp.waitForStableFrame` returns as soon as the window reports
+        // the same frame twice a poll apart, which is what "settled" actually means. The fixed 1.5s
+        // this replaced was both slower than it needed to be on a quiet machine and no guarantee at
+        // all on a loaded CI runner — and the house rules forbid it for exactly that reason.
+        UITestApp.waitForStableFrame(app.windows.firstMatch)
         try capture(named: "workspace.png")
 
         // Journeys. The navigator tab, not a menu item — the same route a reader of the docs takes.
@@ -77,7 +82,7 @@ final class DocScreenshotTests: MimicUITestCase {
         XCTAssertTrue(journeys.waitForExistence(timeout: 5), "The navigator should offer a Journeys tab")
         journeys.click()
 
-        Thread.sleep(forTimeInterval: 1.5)
+        UITestApp.waitForStableFrame(app.windows.firstMatch)
         try capture(named: "journeys.png")
     }
 

--- a/MimicUITests/DocScreenshotTests.swift
+++ b/MimicUITests/DocScreenshotTests.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+import XCTest
+
+/// Regenerates the two screenshots `docs/` embeds, from real application state.
+///
+/// Not a test of behaviour — it asserts only enough to know the frame it captured is the screen it
+/// meant to capture. It exists because `docs/images/workspace.png` and `journeys.png` had drifted a
+/// whole redesign behind the app, and a hand-taken screenshot drifts again the moment anything moves.
+///
+/// **Skipped unless `MIMIC_CAPTURE_DOCS=1`.** It writes into the working tree, which no ordinary test
+/// run should do, and it is slower than the tests around it. Run it deliberately:
+///
+/// ```
+/// MIMIC_CAPTURE_DOCS=1 xcodebuild -workspace Mimic.xcworkspace -scheme Mimic test \
+///   -destination 'platform=macOS' -only-testing:MimicUITests/DocScreenshotTests
+/// ```
+///
+**Grant the runner Documents access before the first run.** macOS raises a TCC prompt —
+/// *"MimicUITests-Runner would like to access files in your Documents folder"* — the first time a run
+/// touches the checkout, and until someone answers it the test **hangs** rather than failing: the
+/// dialog is modal, the runner waits, and `xcodebuild` sits there until it is killed. Worse for this
+/// particular test, the prompt is drawn *over the app*, so a capture taken while it is up has a
+/// system dialog in the middle of the frame. If a run stalls with no output after the first
+/// attachment, look at the screen before looking at the code.
+///
+/// Two traps are load-bearing here and both cost a full re-run when this was first done:
+///
+/// 1. **`app.screenshot()` returns the whole display on macOS**, not the app — desktop, Dock, and
+///    whatever else is open. `app.windows.firstMatch.screenshot()` is the one that returns the
+///    window. The capture helper already in `MimicUITests` uses the former; that is fine for an
+///    xcresult attachment and wrong for a published image.
+/// 2. **Forcing the appearance needs *two* launch arguments.** `-AppleInterfaceStyle Light` alone
+///    does nothing on macOS 26; `-NSRequiresAquaSystemAppearance YES` has to come with it. Both land
+///    in `NSArgumentDomain`, which outranks the global domain, so the developer's own desktop
+///    appearance is untouched by a run.
+final class DocScreenshotTests: MimicUITestCase {
+
+    override func configureLaunchEnvironment(_ app: XCUIApplication) {
+        // Light, per issue #48: both screenshots at the same size in the same appearance.
+        app.launchArguments += [
+            "-AppleInterfaceStyle", "Light",
+            "-NSRequiresAquaSystemAppearance", "YES",
+        ]
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["MIMIC_CAPTURE_DOCS"] == "1",
+            "Set MIMIC_CAPTURE_DOCS=1 to regenerate docs/images. Skipped so an ordinary run does not "
+                + "write into the working tree."
+        )
+    }
+
+    @MainActor
+    func testCaptureWorkspaceAndJourneys() throws {
+        launchApp()
+        createProjectViaUI(name: "Acme API")
+
+        // Enough endpoints for the sidebar to look like a real project rather than an empty one, and
+        // varied enough that the method column shows more than GET.
+        createEndpointViaUI(name: "List users", path: "/api/v1/users")
+        createEndpointViaUI(name: "Create user", path: "/api/v1/users", method: "POST")
+        createEndpointViaUI(name: "User detail", path: "/api/v1/users/{id}")
+        createEndpointViaUI(name: "List orders", path: "/api/v1/orders")
+
+        XCTAssertTrue(workspace.assertVisible(), "The workspace should be on screen before capturing it")
+
+        // Let the window settle. A capture taken mid-transition catches a half-drawn panel, and that
+        // is the kind of defect nobody notices until the image is in the README.
+        Thread.sleep(forTimeInterval: 1.5)
+        try capture(named: "workspace.png")
+
+        // Journeys. The navigator tab, not a menu item — the same route a reader of the docs takes.
+        let journeys = app.buttons["Show journeys"].firstMatch
+        XCTAssertTrue(journeys.waitForExistence(timeout: 5), "The navigator should offer a Journeys tab")
+        journeys.click()
+
+        Thread.sleep(forTimeInterval: 1.5)
+        try capture(named: "journeys.png")
+    }
+
+    /// Writes the front window's own image to `docs/images/<name>`, and attaches it to the result
+    /// bundle so a CI run keeps the evidence even when the working tree is read-only.
+    @MainActor
+    private func capture(named name: String) throws {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.exists, "There should be a window to capture for \(name)")
+
+        let shot = window.screenshot()
+
+        let attachment = XCTAttachment(screenshot: shot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        // Written to a temp directory, **not** into the repository. The UI-test runner is sandboxed,
+        // and a write to `~/Documents/…` from it does not fail cleanly — the first version of this
+        // hung there for twenty minutes with the attachment already made. The caller lifts the PNGs
+        // out afterwards; `Scripts/capture_doc_screenshots.sh` does it with `xcresulttool`.
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimic-doc-screenshots", isDirectory: true)
+        try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        try? shot.pngRepresentation.write(to: destination.appendingPathComponent(name))
+
+        // Report the size, because "the two screenshots are the same size" is an acceptance
+        // criterion of #48 and an assertion nobody can make by looking at the files later.
+        print("CAPTURED \(name) (\(shot.image.size.width)x\(shot.image.size.height))")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ failures, and watch live traffic. Then drive all of it from a script.
 
 [![Platform](https://img.shields.io/badge/platform-macOS%2026%2B-blue)](https://developer.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
-[![Tests](https://img.shields.io/badge/tests-1192%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1193%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Line Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
 [![Module Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json)](#coverage)
@@ -261,7 +261,7 @@ every command through the shipped host. See [AGENTS.md](AGENTS.md#one-host) and
 
 ## Testing
 
-1192 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
+1193 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
 and is still one declaration. Swift Testing for units, XCTest with page objects for UI.
 
 | Suite | Count | Where it runs |
@@ -269,7 +269,7 @@ and is still one declaration. Swift Testing for units, XCTest with page objects 
 | Domain, persistence, engine, control plane, import, CLI | 662 | Linux or macOS — `swift test` |
 | Design system | 72 | macOS — needs SwiftUI |
 | App and coordination | 300 | macOS — hosted by the app |
-| macOS UI (XCUITest) | 158 | macOS, interactive session |
+| macOS UI (XCUITest) | 159 | macOS, interactive session |
 
 The portable 662 break down as Domain 260, SpecImport 128, MimicCLICore 113, MockServerEngine 70,
 Persistence 69, ControlPlane 22. The app's 300 are the six folders `MimicTests` builds —
@@ -298,7 +298,7 @@ published to an orphan `badges` branch as shields.io endpoint payloads. Nothing 
 when they move.
 
 That merge is why the numbers moved. Until it existed the badges came from a run passing
-`-skip-testing:MimicUITests`, so all 158 UI tests — the only ones that touch the SwiftUI layer —
+`-skip-testing:MimicUITests`, so all 159 UI tests — the only ones that touch the SwiftUI layer —
 contributed nothing to the published figure for how well this window is tested.
 
 **The first badge is the weighted total over all nine targets** — covered lines divided by

--- a/Scripts/capture_doc_screenshots.sh
+++ b/Scripts/capture_doc_screenshots.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regenerate docs/images/workspace.png and journeys.png from real application state.
+#
+# The capture itself is `MimicUITests/DocScreenshotTests`, which drives the app, builds a small but
+# realistic project, and screenshots the *window* (not the display — `app.screenshot()` on macOS
+# returns everything, Dock included). It attaches each PNG to the result bundle rather than writing
+# into the repository, because the UI-test runner is sandboxed and a write to `~/Documents/…` from it
+# does not fail cleanly: it hangs, with the attachment already made and nothing on disk.
+#
+# So this script runs the test and then lifts the attachments out of the .xcresult.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+RESULT_BUNDLE="${TMPDIR:-/tmp}/mimic-doc-screenshots.xcresult"
+rm -rf "$RESULT_BUNDLE"
+
+echo "==> Capturing (this drives the real app; do not touch the keyboard)"
+# TEST_RUNNER_ prefix is required: xcodebuild only forwards environment variables to the test
+# process when they carry it. Without the prefix the test skips and the run silently succeeds.
+TEST_RUNNER_MIMIC_CAPTURE_DOCS=1 xcodebuild \
+    -workspace Mimic.xcworkspace \
+    -scheme Mimic \
+    test \
+    -destination 'platform=macOS' \
+    -only-testing:MimicUITests/DocScreenshotTests \
+    -resultBundlePath "$RESULT_BUNDLE" \
+    >/dev/null
+
+echo "==> Extracting attachments"
+STAGING="${TMPDIR:-/tmp}/mimic-doc-screenshots-out"
+rm -rf "$STAGING" && mkdir -p "$STAGING"
+
+xcrun xcresulttool export attachments \
+    --path "$RESULT_BUNDLE" \
+    --output-path "$STAGING" \
+    >/dev/null
+
+# The exporter names files by attachment id and writes `manifest.json` mapping them back. Note it
+# does NOT hand back the name the test set: `attachment.name = "workspace.png"` comes out as
+# `suggestedHumanReadableName = "workspace_0_<uuid>.png"`, so this matches on the stem rather than on
+# equality. Matching exactly finds nothing and the script reports "did not capture" for images it is
+# holding in its hand.
+python3 - "$STAGING" <<'PY'
+import json, pathlib, shutil, sys
+
+staging = pathlib.Path(sys.argv[1])
+images = pathlib.Path(__file__).resolve().parent.parent / "docs" / "images"
+manifest = json.loads((staging / "manifest.json").read_text())
+
+wanted = ("workspace", "journeys")
+found = {}
+for test in manifest:
+    for att in test.get("attachments", []):
+        name = att.get("suggestedHumanReadableName") or att.get("name") or ""
+        for stem in wanted:
+            if name.startswith(stem):
+                found[f"{stem}.png"] = staging / att["exportedFileName"]
+
+missing = {f"{stem}.png" for stem in wanted} - set(found)
+if missing:
+    raise SystemExit(f"Did not capture: {', '.join(sorted(missing))}")
+
+for name, src in sorted(found.items()):
+    dst = images / name
+    shutil.copyfile(src, dst)
+    print(f"    {dst.relative_to(images.parent.parent)}  ({src.stat().st_size:,} bytes)")
+PY
+
+echo "==> Done. Review the images before committing them."


### PR DESCRIPTION
`docs/images/workspace.png` and `journeys.png` were captured on **2 August** and are a whole redesign behind the app — the last open acceptance criterion on #48. A hand-taken replacement drifts again the moment anything moves, so this is a throwaway XCUITest that drives the real app and screenshots the window, plus a script that lifts the PNGs back out.

## Three traps, each of which cost a run

**`app.screenshot()` returns the whole display on macOS**, not the app — desktop, Dock, and whatever else is open. `app.windows.firstMatch.screenshot()` returns the window. The capture helper already in `MimicUITests` uses the former: fine for an xcresult attachment, wrong for a published image.

**Forcing the appearance needs two launch arguments.** `-AppleInterfaceStyle Light` alone does nothing on macOS 26; `-NSRequiresAquaSystemAppearance YES` has to come with it. Both land in `NSArgumentDomain`, which outranks the global domain, so a run leaves the developer's own desktop appearance alone.

**The test must not write into the repository.** The first version did, and macOS raised a TCC prompt:

> "MimicUITests-Runner" would like to access files in your Documents folder.

That prompt is **modal**. The runner waits, `xcodebuild` emits nothing further, and the run hangs until it is killed — it took twenty minutes to notice. The give-away was not in any log: the prompt is drawn *over the app*, so it landed in the middle of the captured frame. The test now writes only to its own temp directory and attaches each PNG; the script extracts them with `xcresulttool`.

One more sharp edge, documented in the script: the exporter does **not** return the name the test set. `attachment.name = "workspace.png"` comes back as `suggestedHumanReadableName = "workspace_0_<uuid>.png"`, so the manifest is matched on the stem. Matching exactly finds nothing and the script reports "did not capture" for images it is holding in its hand.

## Usage

```bash
./Scripts/capture_doc_screenshots.sh
```

Skipped unless `MIMIC_CAPTURE_DOCS=1`, and the `TEST_RUNNER_` prefix is required for `xcodebuild` to forward it — without the prefix the test skips and the run silently succeeds.

## What this PR does not do

**It does not update the images.** The one capture that got far enough has the permission dialog in the middle of it, and answering that prompt is the machine owner's call — not something this change should make on their behalf. Once the runner is granted Documents access, the script produces both images in about a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)