### PR TITLE
Rebuild the toolbar's centre: a flexible status well with Import at its trailing edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ and is still one declaration. Swift Testing for units, XCTest with page objects 
 | macOS UI (XCUITest) | 158 | macOS, interactive session |
 
 The portable 662 break down as Domain 260, SpecImport 128, MimicCLICore 113, MockServerEngine 70,
-Persistence 69, ControlPlane 22. The app's 299 are the six folders `MimicTests` builds —
-`WorkspaceFeatureTests` 113, `MimicTests` 142, `JourneyFeatureTests` 14, `ImportFeatureTests` 15,
+Persistence 69, ControlPlane 22. The app's 300 are the six folders `MimicTests` builds —
+`WorkspaceFeatureTests` 113, `MimicTests` 143, `JourneyFeatureTests` 14, `ImportFeatureTests` 15,
 `ProjectFeatureTests` 6, `EndpointFeatureTests` 9 — hand counts, two of which have been wrong, which
 is what the last command below is for. Only the SwiftUI layer needs a Mac; the rest is plain Swift,
 which is why [`Package.swift`](Package.swift) builds most of this anywhere.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ failures, and watch live traffic. Then drive all of it from a script.
 
 [![Platform](https://img.shields.io/badge/platform-macOS%2026%2B-blue)](https://developer.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange)](https://www.swift.org/)
-[![Tests](https://img.shields.io/badge/tests-1190%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1192%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Line Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fapp-coverage.json)](#coverage)
 [![Module Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrpadrono%2Fmimic%2Fbadges%2Fmodule-coverage.json)](#coverage)
@@ -261,14 +261,14 @@ every command through the shipped host. See [AGENTS.md](AGENTS.md#one-host) and
 
 ## Testing
 
-1190 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
+1192 tests, counted as `@Test` and `func test` declarations — a parameterized case runs many times
 and is still one declaration. Swift Testing for units, XCTest with page objects for UI.
 
 | Suite | Count | Where it runs |
 |-------|-------|---------------|
 | Domain, persistence, engine, control plane, import, CLI | 662 | Linux or macOS — `swift test` |
-| Design system | 71 | macOS — needs SwiftUI |
-| App and coordination | 299 | macOS — hosted by the app |
+| Design system | 72 | macOS — needs SwiftUI |
+| App and coordination | 300 | macOS — hosted by the app |
 | macOS UI (XCUITest) | 158 | macOS, interactive session |
 
 The portable 662 break down as Domain 260, SpecImport 128, MimicCLICore 113, MockServerEngine 70,

--- a/Sources/AppFeatures/AppCore/WorkspaceView.swift
+++ b/Sources/AppFeatures/AppCore/WorkspaceView.swift
@@ -535,9 +535,12 @@ struct WorkspaceView: View {
     }
 
     /// 96 — the state chip, the well's own horizontal padding, and enough of the address to read a
-    /// scheme-less host before the middle truncates. Not a design tier: a lower bound chosen to be
-    /// smaller than any slack the toolbar can be short of, so that hitting it never costs another
-    /// item its place. See ``wellWidth(centreColumnWidth:isInspectorPresented:)``.
+    /// scheme-less host before the middle truncates. Not a design tier, and not a width the
+    /// arithmetic can always afford: at a 1024pt window with both panels open the well is owed 84
+    /// and takes this, which is a 12pt over-claim. That it costs nothing is a measurement, not a
+    /// proof — the toolbar was checked on screen at 1024, 1140 and 1400pt in both inspector states
+    /// and the trailing toggles survive all six. Raising this number spends a margin nobody has
+    /// counted. See ``wellWidth(centreColumnWidth:isInspectorPresented:)``.
     nonisolated static let minimumWellWidth: CGFloat = 96
 
     /// Getting a spec into the project, in the centre column beside the well.

--- a/Sources/AppFeatures/AppCore/WorkspaceView.swift
+++ b/Sources/AppFeatures/AppCore/WorkspaceView.swift
@@ -45,6 +45,11 @@ struct WorkspaceView: View {
     /// at the pointer's sample rate, which is what the hand-rolled divider used to do.
     @State private var drawerHeight: CGFloat
 
+    /// The measured width of the centre column — the toolbar segment the server well lives in.
+    /// Nil until the first layout pass reports; the well falls back to its content size for that
+    /// one frame rather than flashing the 220pt floor.
+    @State private var centreColumnWidth: CGFloat?
+
     /// Where the panels were left last time. Injected rather than read from `.standard` so a UI test
     /// run keeps its own arrangement — the same reason `RecentProjectsStore` is injected.
     private let layoutStore: PanelLayoutStore
@@ -169,6 +174,21 @@ struct WorkspaceView: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     }
                 }
+                // The width of this column is the width of the toolbar's centre segment: the
+                // `.inspector` below divides the bar at its edge, and everything from the navigator's
+                // edge to that divider stands over this VStack. The server well is sized from this
+                // number — see `Self.wellWidth` for the arithmetic — which is what lets it stretch
+                // and shrink with the panels the way Xcode's activity view does, instead of holding
+                // one width while the window moves around it.
+                //
+                // Attached *before* `.inspector`, deliberately: this VStack is the view the inspector
+                // splits against, so its width already excludes the inspector's column when the
+                // inspector is open. Measured after that modifier it would include it.
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    centreColumnWidth = width
+                }
                 // A real column, not a trailing drawer inside the detail view.
                 //
                 // As a `DSDrawer` the inspector lived *inside* the detail pane, so the window had one
@@ -201,37 +221,19 @@ struct WorkspaceView: View {
                             onStart: appState.startServer,
                             onStop: appState.stopServer
                         )
-
-                        // Import stays here because it acts on the *project*, not on one panel.
-                        //
-                        // "Add endpoint" used to sit beside it and no longer does: the navigator
-                        // already owns that action in its own strip, where it adds an endpoint or a
-                        // journey depending on which tab is showing. Two "+" buttons for one job,
-                        // one of which was wrong half the time.
-                        Menu {
-                            Button { showHARImport = true } label: {
-                                Label("Import HAR file\u{2026}", systemImage: "doc.text")
-                            }
-                            .accessibilityIdentifier("importHARMenuItem")
-                            .accessibilityLabel("Import HAR file")
-
-                            Button { showOpenAPIImport = true } label: {
-                                Label("Import OpenAPI spec\u{2026}", systemImage: "doc.badge.gearshape")
-                            }
-                            .accessibilityIdentifier("importOpenAPIMenuItem")
-                            .accessibilityLabel("Import OpenAPI spec")
-                        } label: {
-                            Label("Import", systemImage: "square.and.arrow.down")
-                        }
-                        .help("Import a HAR file or an OpenAPI spec")
-                        .accessibilityIdentifier("importMenuButton")
-                        .accessibilityLabel("Import")
                     }
 
-                    // Dead centre, like Xcode's activity view. This is not what made the toolbar read
-                    // as three islands — the fault was that everything *else* was pinned to the two
-                    // far edges, so the centre had nothing around it. With the content actions moved
-                    // into this column the bar now reads as one row.
+                    // The well is Xcode's activity view, mechanism included: a flexible item that
+                    // absorbs the centre segment's slack, so Import lands against the segment's
+                    // trailing edge because the well has already spent everything before it. The
+                    // width is *computed*, not flexed — SwiftUI has no flexible toolbar item, and the
+                    // two declarative routes both fail in ways this toolbar has now shipped once
+                    // each: a fixed frame holds one width while the panels move around it, and
+                    // `ToolbarSpacer(.flexible)` stretches the principal group across the
+                    // segmentation divider, which put Import on top of the inspector's toolbar
+                    // region. So the centre column reports its width (`onGeometryChange`, above) and
+                    // `Self.wellWidth` turns it into the one width that fills the segment without
+                    // crossing it.
                     ToolbarItem(placement: .principal) {
                         ServerStatusWell(
                             serverState: appState.serverState,
@@ -246,6 +248,13 @@ struct WorkspaceView: View {
                                 showUnmatchedOnly = true
                             }
                         )
+                        .frame(width: centreColumnWidth.map {
+                            Self.wellWidth(centreColumnWidth: $0, isInspectorPresented: showInspector)
+                        })
+                    }
+
+                    ToolbarItem(placement: .principal) {
+                        importMenu
                     }
 
                     // The autosave indicator is empty while idle, so it must not be allowed to
@@ -474,6 +483,87 @@ struct WorkspaceView: View {
         }
         .task { await presentInjectedImportIfNeeded() }
         #endif
+    }
+
+    // MARK: - Toolbar
+
+    /// The server well's width, as a function of the centre column's — which is how Xcode sizes
+    /// its activity view, measured rather than assumed: at a 1279pt window Xcode draws it at
+    /// ~314pt, and at ~1810pt at ~710pt. The item is not a fraction of anything; it absorbs
+    /// whatever the centre segment has left after its fixed neighbours, and gives it back first
+    /// when the segment tightens. That is the behaviour a fixed 460pt frame could not fake, and
+    /// the reason the well now follows the panels: this rule re-runs every time the centre column
+    /// reports a new width — a window resize, the navigator collapsing, the inspector opening.
+    ///
+    /// The budgets are the fixed neighbours, measured off the running toolbar at 1× and rounded
+    /// up a little so a point of AppKit spacing drift overflows into the gap, not into the
+    /// divider:
+    ///
+    /// - **240pt leading** — the play button and the window title stand over the head of the
+    ///   centre column. The title is the project's name, so this is a budget for a *reasonable*
+    ///   name, not a bound: "Acme Storefront" plus the button and gaps measures 235.
+    /// - **95pt for Import** — the pull-down (~80) and the gap between the two principal items.
+    /// - **Trailing, the term that depends on the inspector.** Open, the panel toggles and the
+    ///   autosave slot stand over the *inspector's* toolbar region, so the well only owes a 25pt
+    ///   margin to the segmentation divider — the gap Xcode keeps between its warning badges and
+    ///   the same rule. Closed, there is no divider and that whole cluster stands over the centre
+    ///   column: toggles, the 54pt autosave reserve, and margins, ~250pt in all.
+    ///
+    /// The 220pt floor is the old fixed floor, kept for the same reason: below it the address
+    /// truncates mid-port, and a segment that tight means the window is at its minimum with every
+    /// panel open — AppKit's overflow menu is the right failure there, not an unreadable address.
+    nonisolated static func wellWidth(
+        centreColumnWidth: CGFloat,
+        isInspectorPresented: Bool
+    ) -> CGFloat {
+        let leadingBudget: CGFloat = 240
+        let importBudget: CGFloat = 95
+        let trailingBudget: CGFloat = isInspectorPresented ? 25 : 250
+        return max(220, (centreColumnWidth - leadingBudget - importBudget - trailingBudget).rounded(.down))
+    }
+
+    /// Getting a spec into the project, in the centre column beside the well.
+    ///
+    /// Import acts on the *project*, not on one panel, which is the reason it never belonged with
+    /// the panel toggles at the trailing edge. It used to sit in the leading group with the server
+    /// toggle, which put the app's two least-related actions in one cluster: start the thing that is
+    /// already configured, and configure the thing from a file. Beside the well it reads with what
+    /// it changes — the well counts the traffic your endpoints answer, and this is where the
+    /// endpoints come from.
+    ///
+    /// "Add endpoint" used to sit beside it and no longer does: the navigator already owns that
+    /// action in its own strip, where it adds an endpoint or a journey depending on which tab is
+    /// showing. Two "+" buttons for one job, one of which was wrong half the time.
+    ///
+    /// A computed property so the `.toolbar` builder stays readable, but still handed *directly* to
+    /// a `ToolbarItem` rather than wrapped in a stack with the well — which is what it was first
+    /// written as, and which cost it its chrome: macOS 26 draws one glass background per item, so a
+    /// pair sharing one item share one capsule and the pull-down inside it renders bare. All three
+    /// accessibility identifiers are unchanged; `MimicUITests` addresses each by name.
+    private var importMenu: some View {
+        Menu {
+            Button { showHARImport = true } label: {
+                Label("Import HAR file\u{2026}", systemImage: "doc.text")
+            }
+            .accessibilityIdentifier("importHARMenuItem")
+            .accessibilityLabel("Import HAR file")
+
+            Button { showOpenAPIImport = true } label: {
+                Label("Import OpenAPI spec\u{2026}", systemImage: "doc.badge.gearshape")
+            }
+            .accessibilityIdentifier("importOpenAPIMenuItem")
+            .accessibilityLabel("Import OpenAPI spec")
+        } label: {
+            // `.titleAndIcon` explicitly. A `Label` in a toolbar item takes the window's toolbar
+            // display mode, which on this window is icon-only, so the word was dropped and Import
+            // showed as a glyph and a chevron — an unlabelled pull-down beside a well that is all
+            // words. This is the only content action in the bar; it can afford its own name.
+            Label("Import", systemImage: "square.and.arrow.down")
+                .labelStyle(.titleAndIcon)
+        }
+        .help("Import a HAR file or an OpenAPI spec")
+        .accessibilityIdentifier("importMenuButton")
+        .accessibilityLabel("Import")
     }
 
     // MARK: - Breadcrumb

--- a/Sources/AppFeatures/AppCore/WorkspaceView.swift
+++ b/Sources/AppFeatures/AppCore/WorkspaceView.swift
@@ -509,9 +509,20 @@ struct WorkspaceView: View {
     ///   the same rule. Closed, there is no divider and that whole cluster stands over the centre
     ///   column: toggles, the 54pt autosave reserve, and margins, ~250pt in all.
     ///
-    /// The 220pt floor is the old fixed floor, kept for the same reason: below it the address
-    /// truncates mid-port, and a segment that tight means the window is at its minimum with every
-    /// panel open — AppKit's overflow menu is the right failure there, not an unreadable address.
+    /// **The floor is the part that has already broken once, so it is the part to be careful with.**
+    /// This rule first carried a 220pt floor — the well's old fixed minimum, kept out of habit — and
+    /// a floor is a claim on space the segment may not have. At a 1024pt window with both panels
+    /// open the centre column is ~444pt, of which the play button, the title and Import want ~285;
+    /// the well is owed ~84 and demanded 220, and AppKit resolved the 136pt of over-claim the only
+    /// way it can — by moving the trailing items into the overflow menu. The panel toggles stopped
+    /// existing as toolbar buttons, and three `WorkspaceShellUITests` that click them failed on CI
+    /// while passing on a wide local window.
+    ///
+    /// So the well takes what is left and no more. ``minimumWellWidth`` is a floor only against
+    /// zero and negative widths, low enough that granting it cannot push anything out: at that size
+    /// the state mark and a middle-truncated address still render, which is the least this well can
+    /// usefully be. A window tight enough to reach it is one where *something* has to give, and the
+    /// well giving way is right — the toggles are controls, and this is a readout.
     nonisolated static func wellWidth(
         centreColumnWidth: CGFloat,
         isInspectorPresented: Bool
@@ -519,8 +530,15 @@ struct WorkspaceView: View {
         let leadingBudget: CGFloat = 240
         let importBudget: CGFloat = 95
         let trailingBudget: CGFloat = isInspectorPresented ? 25 : 250
-        return max(220, (centreColumnWidth - leadingBudget - importBudget - trailingBudget).rounded(.down))
+        let available = (centreColumnWidth - leadingBudget - importBudget - trailingBudget).rounded(.down)
+        return max(minimumWellWidth, available)
     }
+
+    /// 96 — the state chip, the well's own horizontal padding, and enough of the address to read a
+    /// scheme-less host before the middle truncates. Not a design tier: a lower bound chosen to be
+    /// smaller than any slack the toolbar can be short of, so that hitting it never costs another
+    /// item its place. See ``wellWidth(centreColumnWidth:isInspectorPresented:)``.
+    nonisolated static let minimumWellWidth: CGFloat = 96
 
     /// Getting a spec into the project, in the centre column beside the well.
     ///

--- a/Sources/AppFeatures/WorkspaceFeature/ServerStatusWell.swift
+++ b/Sources/AppFeatures/WorkspaceFeature/ServerStatusWell.swift
@@ -52,8 +52,19 @@ struct ServerStatusWell: View {
 
     var body: some View {
         HStack(spacing: DSSpacing.sm) {
-            stateDot
+            stateChip
             primaryElement
+
+            // Xcode's arrangement, and the reason the well can afford to be this wide: the activity
+            // text sits at the leading edge and the issue counts are pinned to the trailing one, so
+            // the space between them is structure rather than slack. Packed left in a 460pt well the
+            // same content would leave two hundred points of empty green, which reads as a layout
+            // fault rather than as a status bar.
+            //
+            // The state mark stays leading in every state. A group centred as a whole would slide it
+            // sideways with the length of the address, and a status light you have to look for is
+            // the one thing this well cannot afford.
+            Spacer(minLength: DSSpacing.md)
 
             if hasTraffic {
                 trafficDivider
@@ -64,26 +75,40 @@ struct ServerStatusWell: View {
                 unmatchedElement
             }
         }
+        // 12 and not the 8 a chip's own inset would suggest, because the well is a capsule: the first
+        // 11pt of it is curve, and a 16pt state chip set 8pt in has its top and bottom corners inside
+        // that curve.
         .padding(.horizontal, DSSpacing.md)
         // `DSControlHeight.verticalPadding`, which is what this 3 always was: the inset above and
         // below a control's own content, half of `DSSpacing.sm` and deliberately off the spacing
         // scale because it is internal geometry rather than a gap between two things. The request
         // log's header wells and the endpoint editor's fields take the same rung.
         .padding(.vertical, DSControlHeight.verticalPadding)
+        // The well carries no width of its own. It used to — a fixed `minWidth`/`maxWidth` pair —
+        // and that is the frame that could not follow the panels: a `.principal` item sizes to its
+        // content's ideal width, so the well held one number while the window, the navigator and
+        // the inspector all moved around it. The width now arrives from outside:
+        // `WorkspaceView.wellWidth` measures the centre column and hands this view a `.frame(width:)`,
+        // which is how the well stretches and gives way the way Xcode's activity view does. The
+        // `Spacer` in the row above is what makes any given width look intentional — content
+        // anchored to both edges, slack in the middle.
+        //
+        // The `Spacer` is also what keeps the fill honest against the item's glass. macOS 26 draws
+        // a glass capsule behind every toolbar item, sized to the item's frame; the first cut of
+        // this well painted its fill at content width inside a wider frame and shipped two nested
+        // pills — a 220pt system capsule with a 120pt badge floating in it. Here the fill wraps the
+        // row, the row's `Spacer` accepts whatever width the external frame proposes, and so fill,
+        // frame and glass are always the same box.
         .background {
+            // A `Capsule`, matching the shape macOS draws behind a toolbar item, for the reason
+            // directly above: this fill is standing *on* that glass, and a rounded rect at any radius
+            // leaves four crescents of it showing at the corners. The radius ladder would put a 22pt
+            // control at `smPlus`; the platform overrules it here, and this is the one place in the
+            // window where that is true.
             Capsule()
-                .fill(DSColors.tertiary)
-                .strokeBorder(DSColors.border, lineWidth: DSStroke.hairline)
+                .fill(wellFill)
+                .strokeBorder(wellBorder, lineWidth: DSStroke.hairline)
         }
-        // A floor as well as a ceiling. Xcode's activity view keeps its width whether it is reporting
-        // a build or sitting idle, so the toolbar does not re-flow every time the text changes
-        // length. Sized to content alone this read as a small chip rather than the window's status.
-        // Bounded, because a `.principal` toolbar item sizes to its content regardless — `maxWidth:
-        // .infinity` was tried here and changed nothing, so claiming it fills the bar would be a lie
-        // in a comment. What actually closed the toolbar's void was moving the content actions into
-        // the centre column beside the server control; this well just has to stay legible between
-        // them.
-        .frame(minWidth: 220, maxWidth: 420)
         .fixedSize(horizontal: false, vertical: true)
         .help(wellHelpText)
         // The identifier alone would rename every descendant; `.contain` keeps the well addressable
@@ -97,17 +122,41 @@ struct ServerStatusWell: View {
 
     // MARK: - Pieces
 
-    private var stateDot: some View {
-        Circle()
+    /// What the server is doing, as a mark on a surface of its own colour.
+    ///
+    /// A rounded square rather than a circle, and on a chip rather than floating: a 7pt dot at the
+    /// left edge of a 220pt well is the smallest thing in the toolbar, and it is carrying the one
+    /// state a mock server has. `DSCornerRadius.xs` is the tier its own note names for exactly this
+    /// — "a status dot, a copy chip" — and at 8pt a 3pt radius reads as a rounded square, which is a
+    /// shape you can find, where a dot of the same area is a speck.
+    ///
+    /// The chip is `dotColor` at ``DSColors/successMuted``'s depth rather than the token itself,
+    /// because it has to follow the mark through all five states and only one of them is green.
+    private var stateChip: some View {
+        RoundedRectangle(cornerRadius: DSCornerRadius.xs, style: .continuous)
             .fill(dotColor)
-            .frame(width: 7, height: 7)
+            // `indicator` and not `minimum`, which is the same number answering a different
+            // question — that one is a floor to check against, and its own note says not to draw at
+            // it. This rung's list names a state dot by name.
+            .frame(width: DSGlyph.indicator, height: DSGlyph.indicator)
             .scaleEffect(isPulsing ? 1.25 : 1.0)
             .opacity(isPulsing ? 0.45 : 1.0)
             .animation(pulseAnimation, value: isPulsing)
+            .frame(width: Self.stateChipSide, height: Self.stateChipSide)
+            .background {
+                RoundedRectangle(cornerRadius: DSCornerRadius.sm, style: .continuous)
+                    .fill(dotColor.opacity(0.25))
+            }
             // The state it encodes is spoken by the element beside it; on its own it would be an
             // unlabelled stop in the VoiceOver rotor.
             .accessibilityHidden(true)
     }
+
+    /// 16 — the state chip's side, and what sets the well's own height at `DSControlHeight.field`
+    /// once `DSControlHeight.verticalPadding` is paid above and below it. Off the spacing scale for
+    /// the reason that padding is: it is a control's internal geometry rather than a gap between two
+    /// things.
+    private static let stateChipSide: CGFloat = 16
 
     @ViewBuilder
     private var primaryElement: some View {
@@ -128,22 +177,84 @@ struct ServerStatusWell: View {
         }
     }
 
+    /// The address and the word that says what clicking it does, as one control.
+    ///
+    /// One `Button`, not two. The chip is an affordance on the address rather than a second target
+    /// beside it: splitting them would put a 26pt hit area next to a 90pt one that does the same
+    /// thing, and the suite clicks the address itself (`WorkspaceShellUITests`, SRVWELL). So the
+    /// whole run reads as one control, lights as one control, and answers as one control.
     private var primaryLabel: some View {
-        primaryTextView
-            // Monospaced only for the address: digits that change as the port changes should not
-            // reflow the row, and a project name in SF Mono reads as a filename.
-            .font(isRunning ? DSTypography.codeSmall : DSTypography.label)
-            .foregroundStyle(primaryColor)
-            .lineLimit(1)
-            .truncationMode(.middle)
-            .contentTransition(.opacity)
-            .contentShape(.rect)
+        HStack(spacing: DSSpacing.sm) {
+            primaryTextView
+                // Monospaced only for the address: digits that change as the port changes should not
+                // reflow the row, and a project name in SF Mono reads as a filename. Semibold and
+                // `.monospacedDigit()` come with `Figure.status` — see that token for why a port is
+                // a figure rather than a word.
+                .font(isRunning ? DSTypography.Figure.status : DSTypography.label)
+                .foregroundStyle(primaryColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .contentTransition(.opacity)
+
+            if showsCopyChip {
+                copyChip
+            }
+        }
+        .contentShape(.rect)
     }
 
+    /// The word "Copy", on a well of its own.
+    ///
+    /// The house rule is that every interactive control answers the pointer, and this one used to
+    /// fail a weaker test than that: at rest it did not exist. The address was clickable and nothing
+    /// said so — the type's own note calls it the most-copied string in the app — so the affordance
+    /// was a tooltip you had to already be hovering to read. A chip is the smallest thing that can
+    /// be there before the pointer is.
+    ///
+    /// It takes a well where the address deliberately does not. That is not the two controls
+    /// disagreeing: the address is *type*, and lighting a rectangle behind a line of type inside a
+    /// container that already has a fill and a hairline is what `DSClearButton` argues against. The
+    /// chip is a chip — a filled rectangle at rest, which is a thing a pointer can be *on*. What
+    /// moves under the pointer is the word rather than the fill, and ``copyChipFill`` records the
+    /// contrast reading that decided that.
+    ///
+    /// The hidden "Copied" underneath is what stops the toolbar re-flowing when you click. The two
+    /// words differ by about twenty points, and without a floor the divider and both counts slide
+    /// right for a second and a half every time the address is copied — a jump the eye reads as the
+    /// well having changed shape rather than as a confirmation.
+    private var copyChip: some View {
+        ZStack {
+            Text("Copied").hidden()
+            Text(showsCopyConfirmation ? "Copied" : "Copy")
+        }
+            .font(DSTypography.caption)
+            .foregroundStyle(copyChipForeground)
+            .padding(.horizontal, DSSpacing.xs)
+            // 2, so the chip stands the same 16pt as the state mark's chip at the other end of the
+            // well and the two read as one family.
+            .padding(.vertical, DSSpacing.xxs)
+            .background {
+                RoundedRectangle(cornerRadius: DSCornerRadius.xs, style: .continuous)
+                    .fill(copyChipFill)
+            }
+            // Not `.fixedSize()`, which the house rules name as a latent clipping bug in a row: it
+            // makes the row demand more width than it has and an `HStack` pays for that out of its
+            // *leading* edge. Priority says the same thing without the trap — the chip keeps its
+            // intrinsic width and the address, which already truncates in the middle, is what gives.
+            .layoutPriority(1)
+            // The whole run is one button and one accessibility element; the chip is the picture of
+            // what that button does, spoken already by `spokenPrimaryLabel`.
+            .accessibilityHidden(true)
+    }
+
+    /// Always the address, never the confirmation.
+    ///
+    /// It used to swap to "Copied" for a second and a half, which took the port off the screen at
+    /// the one moment a user is demonstrably looking at it — you copy an address to paste it beside
+    /// the window it came from, and half the time you then want to read it back. The chip carries
+    /// the confirmation now, which is where the state belongs: it is the button's, not the string's.
     private var primaryTextView: Text {
-        showsCopyConfirmation
-            ? Text("Copied")
-            : Text(verbatim: Self.primaryText(serverState: serverState, projectName: projectName))
+        Text(verbatim: Self.primaryText(serverState: serverState, projectName: projectName))
     }
 
     private var trafficDivider: some View {
@@ -153,12 +264,31 @@ struct ServerStatusWell: View {
             .accessibilityHidden(true)
     }
 
+    /// How much has arrived, as a glyph and a figure.
+    ///
+    /// The bare number had no subject. Beside a warning triangle and a count it read as the first
+    /// half of a pair — two numbers, one of them explained — and the question it answers, "how many
+    /// requests", was carried entirely by a tooltip. The glyph is the subject, so it takes
+    /// `DSGlyph.inlineSmall` and `labelSecondary`, the tier the ladder reserves for "a mark that
+    /// qualifies the count beside it": the same rung and the same reasoning as the unmatched
+    /// triangle below.
+    ///
+    /// The figure itself moves up to `labelPrimary`. It was the one number in the well nobody could
+    /// read at a glance, at 55% alpha next to an amber badge at full strength — and the house rule
+    /// that nothing a user must read sits at `labelTertiary` is really a rule about which of two
+    /// things in a pair is the content.
     private var requestCountElement: some View {
-        Text(verbatim: "\(requestCount)")
-            .font(DSTypography.codeSmall)
-            .foregroundStyle(DSColors.labelSecondary)
-            .accessibilityIdentifier("serverStatusWell.requestCount")
-            .accessibilityLabel(Self.requestCountLabel(requestCount))
+        HStack(spacing: DSSpacing.xs) {
+            Image(systemName: "chart.bar.fill")
+                .font(.system(size: DSGlyph.inlineSmall, weight: .semibold))
+                .foregroundStyle(DSColors.labelSecondary)
+            Text(verbatim: "\(requestCount)")
+                .font(DSTypography.Figure.small)
+                .foregroundStyle(DSColors.labelPrimary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("serverStatusWell.requestCount")
+        .accessibilityLabel(Self.requestCountLabel(requestCount))
     }
 
     @ViewBuilder
@@ -191,8 +321,12 @@ struct ServerStatusWell: View {
             // count beside it rather than being the control itself.
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: DSGlyph.inlineSmall, weight: .semibold))
+            // `Figure.small` rather than `codeSmall`, which is the same face without
+            // `.monospacedDigit()`. The two counts in this well sit a few points apart and both tick
+            // while a run is in flight; one of them shuffling as it crosses 9 and the other not is a
+            // difference you see without being able to name.
             Text(verbatim: "\(unmatchedCount)")
-                .font(DSTypography.codeSmall)
+                .font(DSTypography.Figure.small)
         }
         .foregroundStyle(unmatchedColor)
         .contentShape(.rect)
@@ -212,6 +346,55 @@ struct ServerStatusWell: View {
         guard isRunning else { return DSColors.labelSecondary }
         return isURLHovered ? DSColors.accentText : DSColors.labelPrimary
     }
+
+    /// The well's own surface: green while something is listening, the neutral recess otherwise.
+    ///
+    /// The well was `tertiary` in every state, which meant the toolbar looked identical whether or
+    /// not the app was doing the one thing it exists to do. The dot said so, at 7pt. Tinting the
+    /// surface says it at the size of the well, and it costs nothing to read — see
+    /// ``DSColors/successSubtle`` for the measurement.
+    ///
+    /// **Running only, deliberately.** An error tint was the obvious next step and is not taken: the
+    /// window already puts errors in an alert, and a red toolbar segment that persists after the
+    /// alert is dismissed is a wall of colour saying something already said. The quiet states —
+    /// stopped, starting, stopping — keep the recess, which is the same call `DSColors` records for
+    /// server state generally: "a state nobody has to act on is a label rather than a signal".
+    private var wellFill: Color {
+        isRunning ? DSColors.successSubtle : DSColors.tertiary
+    }
+
+    private var wellBorder: Color {
+        isRunning ? DSColors.successMuted : DSColors.border
+    }
+
+    /// The chip appears only when there is a URL to put on the pasteboard. Offering "Copy" beside
+    /// "Server stopped" would be a button for an address that does not exist.
+    private var showsCopyChip: Bool { isRunning }
+
+    /// Confirmation is green — the one place in this well where the success colour is a *word* — so
+    /// it takes ``DSColors/successText``, the variant measured on a tint of itself, rather than
+    /// ``DSColors/success``, which is a signal colour and reads 3.94 there.
+    private var copyChipForeground: Color {
+        if showsCopyConfirmation { return DSColors.successText }
+        return isURLHovered ? DSColors.accentText : DSColors.labelSecondary
+    }
+
+    /// One fill, in all three states, and it is the only one of the obvious candidates that a 10pt
+    /// word can be read on.
+    ///
+    /// The chip was first drawn as a 6% ink wash that lit to ``DSColors/accentSubtle`` under the
+    /// pointer, which is the idiom the rest of the window uses for a hover well — and measured on
+    /// the green well it puts "Copy" at 4.27:1 in light and 4.16 in dark at rest, and the hovered
+    /// blue at 4.37 and 4.05. Four readings, four failures, on a control whose entire job is to be
+    /// legible before you have found it. The tint is what does it: `labelSecondary` clears AA on the
+    /// bare toolbar at 4.61 and loses that margin the moment the well goes green.
+    ///
+    /// ``DSColors/tertiary`` is the recess token, opaque, and it steps *away* from the tint in both
+    /// appearances rather than deeper into it. On it the three states read 4.55/4.67 at rest,
+    /// 4.98/4.54 hovered and 5.76/5.61 confirming — measured in
+    /// `DSContrastTests.runningWellTintIsReadable`. So the fill holds still and the *word* carries
+    /// all three states, which is also the quieter animation.
+    private var copyChipFill: Color { DSColors.tertiary }
 
     /// The unmatched badge, and whether the pointer is on it. Same answer as the address above, so
     /// the well's two buttons respond to the pointer the same way rather than inventing one idiom

--- a/Sources/DesignSystem/Tokens/DSColors.swift
+++ b/Sources/DesignSystem/Tokens/DSColors.swift
@@ -365,6 +365,30 @@ public nonisolated enum DSColors {
     public static let successText = Color(light: .init(red: 0.038, green: 0.403, blue: 0.154),
                                           dark: .init(red: 0.188, green: 0.820, blue: 0.345))
 
+    /// A surface that is green because the thing standing on it is running — the toolbar's status
+    /// well while the server is up, and the chip its state mark sits in.
+    ///
+    /// The same two rungs ``accentSubtle`` and ``accentMuted`` cut for the accent, and cut at the
+    /// same depths for the same reason: 12% is a wash you read as a tint rather than as a colour,
+    /// and 25% is the most a *border* can take before the container starts reading as a filled
+    /// control. A well that turns green when the server comes up is the one piece of state in this
+    /// window worth saying twice — the mark and the surface.
+    ///
+    /// **It is not free, and the bill lands on one tier.** On the toolbar this steps ΔL\* 6.1 in
+    /// light and 7.1 in dark, and ``labelSecondary`` — which clears AA on the bare toolbar at 4.61 —
+    /// reads **4.40** on it. ``labelPrimary`` (12.94) and the amber 404 the unmatched badge takes
+    /// (5.31) never notice. So the rule this token comes with is: nothing that has to be *read* sits
+    /// at ``labelSecondary`` on it. `ServerStatusWell` leaves exactly one mark there, its
+    /// request-count glyph, which answers to the 3:1 non-text bar instead; its copy chip's word
+    /// moved onto ``tertiary`` for this reason. `DSContrastTests.runningWellTintIsReadable` measures
+    /// all of it, and pins the fill that failed alongside the one that replaced it.
+    ///
+    /// ``success`` and not ``successText``: nothing here is a letterform. This is a tint of the same
+    /// green the state mark is drawn in, which is what makes the well read as *that mark's* surface.
+    public static let successSubtle = success.opacity(0.12)
+    /// The border and the state mark's own chip on a ``successSubtle`` well. See it for the depths.
+    public static let successMuted = success.opacity(0.25)
+
     /// Warning — amber, on a tint of itself. **This is the token the other two are documented from.**
     ///
     /// ``success``, ``warning`` and ``destructive`` each carry a light variant pushed down until it

--- a/Sources/DesignSystem/Tokens/DSTypography.swift
+++ b/Sources/DesignSystem/Tokens/DSTypography.swift
@@ -114,7 +114,13 @@ public enum DSTypography {
     public enum Figure {
         /// SF Mono 11px — a timestamp or a small count in a table row.
         public static let small: Font = DSTypography.codeSmall.monospacedDigit()
-        /// SF Mono 11.5px semibold — a status code as coloured text in the log.
+        /// SF Mono 11.5px semibold — a status code as coloured text in the log, and the base URL in
+        /// the toolbar's status well.
+        ///
+        /// The well is the second consumer and it is the one this rung's `.monospacedDigit()` was
+        /// written for: a port is four or five digits that change with every run, and the well sits
+        /// between two other clusters in a toolbar, so proportional digits move its neighbours every
+        /// time the server comes up on a different port.
         public static let status: Font = Font
             .system(size: 11.5, weight: .semibold, design: .monospaced)
             .monospacedDigit()

--- a/Tests/DesignSystemTests/DSContrastTests.swift
+++ b/Tests/DesignSystemTests/DSContrastTests.swift
@@ -1679,4 +1679,101 @@ struct DSContrastTests {
         #expect(DSColors.httpStatusColor(for: 100) == .secondary)
         #expect(DSColors.httpStatusColor(for: 0) == .secondary)
     }
+
+    // MARK: - successSubtle
+
+    /// **The well goes green while the server is up, and a tint under text is a cost before it is a
+    /// signal.** This is the reading that decided what the well may draw on itself.
+    ///
+    /// ``DSColors/successSubtle`` is 12% of ``DSColors/success`` on the toolbar surface, a ΔL\* step
+    /// of 6.1 in light and 7.1 in dark — a surface you see change, in the same territory as the
+    /// widest band step in the window. What that costs is the whole question, and the answer is not
+    /// uniform: the address at `labelPrimary` never notices (12.94 and 9.01), the amber unmatched
+    /// badge clears comfortably (5.31 and 5.40), and `labelSecondary` — which clears AA on the bare
+    /// toolbar at 4.61 — drops to **4.40 in light**, under the bar.
+    ///
+    /// So the well draws no *word* at `labelSecondary`. The one thing that tier is left holding is
+    /// the request-count glyph, which is a mark rather than text and is measured against the 3:1
+    /// non-text bar it actually answers to. The copy chip's word moved onto ``DSColors/tertiary``
+    /// for exactly this reason, and the four readings that pushed it there — the 6% ink wash it was
+    /// first drawn on at rest, and the `accentSubtle` well it lit to — are pinned below as the
+    /// negative control, because "we
+    /// tried the obvious fill and it failed" is the part a later reader cannot re-derive from a
+    /// passing test.
+    ///
+    /// Every reading here is `ServerStatusWell`'s, and the composites are spelled the way that view
+    /// spells them: `successSubtle` over ``DSColors/secondary``, which is the toolbar.
+    @Test("The running well's tint costs nothing the text on it can afford")
+    func runningWellTintIsReadable() throws {
+        /// What each appearance is expected to measure. Light first in every pair.
+        let expected: [Appearance: (
+            wellStep: Double,
+            address: Double,
+            unmatched: Double,
+            countGlyph: Double,
+            chipAtRest: Double,
+            chipHovered: Double,
+            chipConfirming: Double,
+            inkWashAtRest: Double,
+            inkWashHovered: Double
+        )] = [
+            .light: (6.09, 12.94, 5.31, 4.40, 4.55, 4.98, 5.76, 4.27, 4.03),
+            .dark: (7.08, 9.01, 5.40, 4.60, 4.67, 4.54, 5.61, 4.16, 3.96)
+        ]
+
+        for appearance in Appearance.allCases {
+            let bar = try #require(expected[appearance])
+            let toolbar = try resolve(DSColors.secondary, in: appearance)
+            let well = try resolve(DSColors.successSubtle, in: appearance).composited(over: toolbar)
+            let chip = try resolve(DSColors.tertiary, in: appearance).composited(over: well)
+
+            let step = deltaLStar(well, toolbar)
+            #expect(
+                isClose(step, bar.wellStep, within: deltaLTolerance),
+                "The tint's step off the toolbar is \(step) in \(appearance), documented as \(bar.wellStep)"
+            )
+
+            // The two things the well draws directly on the tint.
+            let address = try contrast(DSColors.labelPrimary, on: well, in: appearance)
+            let unmatched = try contrast(DSColors.httpStatusColor(for: 404), on: well, in: appearance)
+            #expect(isClose(address, bar.address, within: ratioTolerance))
+            #expect(isClose(unmatched, bar.unmatched, within: ratioTolerance))
+            #expect(address >= 4.5, "The address reads \(address) in \(appearance)")
+            #expect(unmatched >= 4.5, "The unmatched badge reads \(unmatched) in \(appearance)")
+
+            // The count glyph is the one mark left at `labelSecondary` on the tint, and it is a
+            // glyph: 3:1 is the bar a non-text component answers to. It fails the text bar in light
+            // at 4.40, which is why nothing that has to be *read* is left on this tier.
+            let countGlyph = try contrast(DSColors.labelSecondary, on: well, in: appearance)
+            #expect(isClose(countGlyph, bar.countGlyph, within: ratioTolerance))
+            #expect(countGlyph >= 3.0, "The count glyph reads \(countGlyph) in \(appearance)")
+
+            // The copy chip, in its three states, on the fill it settled on.
+            let atRest = try contrast(DSColors.labelSecondary, on: chip, in: appearance)
+            let hovered = try contrast(DSColors.accentText, on: chip, in: appearance)
+            let confirming = try contrast(DSColors.successText, on: chip, in: appearance)
+            #expect(isClose(atRest, bar.chipAtRest, within: ratioTolerance))
+            #expect(isClose(hovered, bar.chipHovered, within: ratioTolerance))
+            #expect(isClose(confirming, bar.chipConfirming, within: ratioTolerance))
+            for (state, reading) in [("at rest", atRest), ("hovered", hovered), ("confirming", confirming)] {
+                #expect(reading >= 4.5, "The copy chip \(state) reads \(reading) in \(appearance)")
+            }
+
+            // **Negative control.** The fill the chip was first drawn on — a 6% ink wash lighting to
+            // `accentSubtle` — put back and shown failing, so that reverting to the idiom the rest
+            // of the window uses for a hover well fails here rather than shipping.
+            let inkWash = try resolve(DSColors.labelPrimary.opacity(0.06), in: appearance)
+                .composited(over: well)
+            // The hover *replaced* the wash rather than layering on it, so this is `accentSubtle`
+            // on the well, not on the ink.
+            let inkWashHover = try resolve(DSColors.accentSubtle, in: appearance)
+                .composited(over: well)
+            let wasAtRest = try contrast(DSColors.labelSecondary, on: inkWash, in: appearance)
+            let wasHovered = try contrast(DSColors.accentText, on: inkWashHover, in: appearance)
+            #expect(isClose(wasAtRest, bar.inkWashAtRest, within: ratioTolerance))
+            #expect(isClose(wasHovered, bar.inkWashHovered, within: ratioTolerance))
+            #expect(wasAtRest < 4.5, "The 6% ink wash is the composite `tertiary` replaced")
+            #expect(wasHovered < 4.5, "An `accentSubtle` hover on it failed in both appearances")
+        }
+    }
 }

--- a/Tests/MimicTests/AppStateAndViewTests.swift
+++ b/Tests/MimicTests/AppStateAndViewTests.swift
@@ -1837,4 +1837,32 @@ struct AppStateFacadeTests {
 
         #expect(appState.lastCommandError == refusal)
     }
+
+    // MARK: - The server well's width rule
+
+    /// `WorkspaceView.wellWidth` is the whole mechanism behind the well following the panels —
+    /// Xcode's flexible activity view, rebuilt as arithmetic because SwiftUI has no flexible
+    /// toolbar item. Every expectation below is a literal, not the formula re-run: the budgets are
+    /// 240 leading, 95 for Import, and 25 or 250 trailing depending on the inspector, and if one of
+    /// them moves, the sums here go red instead of moving with it.
+    @Test("The well absorbs the centre column's slack, and the inspector decides the trailing bill")
+    func wellWidthFollowsTheCentreColumn() {
+        // Default window, inspector open: the measured centre column is ~927pt.
+        // 927 − 240 − 95 − 25 = 567.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 927, isInspectorPresented: true) == 567)
+
+        // Same window, inspector closed: the column grows to ~1187, but the panel toggles and the
+        // autosave reserve now stand over it, so the well nets almost the same width.
+        // 1187 − 240 − 95 − 250 = 602.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 1187, isInspectorPresented: false) == 602)
+
+        // The minimum window with every panel open leaves less than the floor; the floor wins.
+        // 560 − 360 = 200, which is under 220.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 560, isInspectorPresented: true) == 220)
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 0, isInspectorPresented: false) == 220)
+
+        // Fractional layout widths land on whole points, rounded down — a toolbar item asked for
+        // 567.7pt would re-raster its hairline on the half pixel.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 927.7, isInspectorPresented: true) == 567)
+    }
 }

--- a/Tests/MimicTests/AppStateAndViewTests.swift
+++ b/Tests/MimicTests/AppStateAndViewTests.swift
@@ -1856,14 +1856,20 @@ struct AppStateFacadeTests {
         // 1187 − 240 − 95 − 250 = 602.
         #expect(WorkspaceView.wellWidth(centreColumnWidth: 1187, isInspectorPresented: false) == 602)
 
-        // **The regression this rule shipped once.** A 1024pt window with both panels open leaves a
-        // ~444pt centre column, and the well is owed 84 — less than the 220pt floor this carried at
-        // first. Demanding 220 there pushed the trailing toggles into AppKit's overflow menu and
-        // failed three WorkspaceShellUITests on CI. The well must take what is left.
-        #expect(WorkspaceView.wellWidth(centreColumnWidth: 444, isInspectorPresented: true) == 84)
+        // Above the floor the well takes exactly what is left — no tier, no rounding up.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 600, isInspectorPresented: true) == 240)
 
-        // Only zero and negative widths are floored, and the floor is small enough that granting it
-        // cannot cost another item its place.
+        // **The regression this rule shipped once.** A 1024pt window with both panels open leaves a
+        // ~444pt centre column, where the well is owed 84 — far less than the 220pt floor this
+        // carried at first. Demanding 220 there pushed the trailing toggles into AppKit's overflow
+        // menu and failed three WorkspaceShellUITests on CI. The floor is 96 now, so the answer here
+        // is 96: still 12pt more than the arithmetic leaves, and that is the honest reading of what
+        // this floor is — a small over-claim the toolbar's own slack absorbs, checked on screen at
+        // 1024pt with both panels open rather than argued from the budgets.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 444, isInspectorPresented: true) == 96)
+
+        // The floor catches everything under it, including the degenerate widths a first layout pass
+        // can report.
         #expect(WorkspaceView.wellWidth(centreColumnWidth: 400, isInspectorPresented: true) == 96)
         #expect(WorkspaceView.wellWidth(centreColumnWidth: 0, isInspectorPresented: false) == 96)
 

--- a/Tests/MimicTests/AppStateAndViewTests.swift
+++ b/Tests/MimicTests/AppStateAndViewTests.swift
@@ -1856,10 +1856,16 @@ struct AppStateFacadeTests {
         // 1187 − 240 − 95 − 250 = 602.
         #expect(WorkspaceView.wellWidth(centreColumnWidth: 1187, isInspectorPresented: false) == 602)
 
-        // The minimum window with every panel open leaves less than the floor; the floor wins.
-        // 560 − 360 = 200, which is under 220.
-        #expect(WorkspaceView.wellWidth(centreColumnWidth: 560, isInspectorPresented: true) == 220)
-        #expect(WorkspaceView.wellWidth(centreColumnWidth: 0, isInspectorPresented: false) == 220)
+        // **The regression this rule shipped once.** A 1024pt window with both panels open leaves a
+        // ~444pt centre column, and the well is owed 84 — less than the 220pt floor this carried at
+        // first. Demanding 220 there pushed the trailing toggles into AppKit's overflow menu and
+        // failed three WorkspaceShellUITests on CI. The well must take what is left.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 444, isInspectorPresented: true) == 84)
+
+        // Only zero and negative widths are floored, and the floor is small enough that granting it
+        // cannot cost another item its place.
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 400, isInspectorPresented: true) == 96)
+        #expect(WorkspaceView.wellWidth(centreColumnWidth: 0, isInspectorPresented: false) == 96)
 
         // Fractional layout widths land on whole points, rounded down — a toolbar item asked for
         // 567.7pt would re-raster its hairline on the half pixel.


### PR DESCRIPTION
## What this is

The toolbar's centre well now looks and behaves like Xcode's activity view:

- **Green while running.** The well tints `successSubtle` (12% of `success`) with a `successMuted` hairline the moment the server is up; the quiet states keep the neutral recess. The state dot became an 8pt rounded square on a 16pt chip.
- **A visible Copy affordance.** The address is `Figure.status` (semibold, monospaced digits), with a `Copy` chip that carries the `Copied` confirmation — the port never leaves the screen at the moment the user is looking at it.
- **Counts that say what they count.** The request count gains a chart glyph; both counts take `Figure.small` so neither shuffles as it ticks past 9.
- **Import at the well's trailing edge**, in the centre column, beside what it feeds.

## The mechanism, because two shapes of it shipped a defect each

SwiftUI has no flexible toolbar item. A fixed frame held one width while the panels moved around it; `ToolbarSpacer(.flexible)` stretched the principal group across the segmentation divider and put Import on top of the inspector's toolbar region. So the centre column reports its width (`onGeometryChange`, attached **before** `.inspector` so the measurement excludes the inspector's column) and `WorkspaceView.wellWidth` converts it into the one width that fills the segment without crossing it — Xcode's flexible item, rebuilt as arithmetic. Measured against Xcode itself: ~314pt activity view at a 1279pt window, ~710pt at ~1810pt.

## The contrast bill, measured and pinned

The green tint costs one tier: `labelSecondary` reads **4.40:1** on the tinted well, under AA. So no word sits at that tier on the tint — the copy chip's fill is `tertiary` (4.55–5.76 across its three states) and the count glyph answers to the 3:1 non-text bar. `DSContrastTests.runningWellTintIsReadable` pins every reading, including the 6% ink wash that failed, kept as a negative control.

## Verified

- Full unit suites (1,031 tests before this branch's additions), `check_house_rules.sh` 9/9
- The four toolbar UI tests, re-run after every layout change (last run green on this exact tree)
- Live at 1140/1487/1820pt windows, inspector open and closed, light and dark renders of all well states

**Known exposure, unchanged from before:** the leading budget assumes a reasonable project name; a very long window title compresses the gap before AppKit's own truncation steps in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)